### PR TITLE
Improve bcodec encode performance

### DIFF
--- a/ntex-codec/src/bcodec.rs
+++ b/ntex-codec/src/bcodec.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut, Buf};
 use std::io;
 
 use super::{Decoder, Encoder};
@@ -13,9 +13,9 @@ impl Encoder for BytesCodec {
     type Item = Bytes;
     type Error = io::Error;
 
+    #[inline]
     fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.reserve(item.len());
-        dst.put(item);
+        dst.extend_from_slice(item.bytes());
         Ok(())
     }
 }


### PR DESCRIPTION
Remove repeat calls to `reverve` method. Stop treating `item` since it has the assured drop. Add the inline attribute because the resulting body is just one line.