### PR TITLE
support wrap in router macro

### DIFF
--- a/ntex-macros/src/route.rs
+++ b/ntex-macros/src/route.rs
@@ -92,7 +92,7 @@ impl Args {
                             return Err(syn::Error::new_spanned(
                                 nv.lit,
                                 "Attribute wrap expects type",
-                            ))
+                            ));
                         }
                     } else {
                         return Err(syn::Error::new_spanned(


### PR DESCRIPTION
support following code:
#[get("/index", wrap = "middleware::CustomMiddleware")]
async fn index() ...