### PR TITLE
Simplify task LocalWaker register method

### DIFF
--- a/ntex/src/task.rs
+++ b/ntex/src/task.rs
@@ -46,12 +46,7 @@ impl LocalWaker {
     ///
     /// Returns `true` if waker was registered before.
     pub fn register(&self, waker: &Waker) -> bool {
-        unsafe {
-            let w = self.waker.get();
-            let is_registered = (*w).is_some();
-            *w = Some(waker.clone());
-            is_registered
-        }
+        unsafe { self.waker.get().replace(Some(waker.clone())).is_some() }
     }
 
     #[inline]


### PR DESCRIPTION
Simplify register waker with `replace` method of mutable pointer 