### PR TITLE
fix rustls connect

### DIFF
--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.3.19] - 2021-06-23
+
+* rustls connector - #50 fix rustls connect to work around a port in hostname (giving invalid DNS)
+
 ## [0.3.18] - 2021-06-03
 
 * server: expose server status change notifications

--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex"
-version = "0.3.18"
+version = "0.3.19"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "Framework for composable network services"
 readme = "README.md"

--- a/ntex/src/connect/rustls.rs
+++ b/ntex/src/connect/rustls.rs
@@ -37,7 +37,7 @@ impl<T: Address + 'static> RustlsConnector<T> {
         Connect<T>: From<U>,
     {
         let req = Connect::from(message);
-        let host = req.host().to_string();
+        let host = req.host().split(":").next().unwrap().to_owned();
         let conn = self.connector.call(req);
         let config = self.config.clone();
 


### PR DESCRIPTION
Since host() contains name:port, TLS fails with invalid DNS - #50. This hotfix removes the port from the host string.