### PR TITLE
fixed description for Response::status_mut

### DIFF
--- a/ntex/src/http/response.rs
+++ b/ntex/src/http/response.rs
@@ -82,7 +82,7 @@ impl<B> Response<B> {
         self.head.status
     }
 
-    /// Set the `StatusCode` for this response
+    /// Get the `StatusCode` for this response
     #[inline]
     pub fn status_mut(&mut self) -> &mut StatusCode {
         &mut self.head.status


### PR DESCRIPTION
Fixed description of  `pub fn status_mut(&mut self) -> &mut StatusCode`