### PR TITLE
[WIP] Allow ntex to use external buffer pools.

### DIFF
--- a/ntex-bytes/src/buf/mod.rs
+++ b/ntex-bytes/src/buf/mod.rs
@@ -19,11 +19,17 @@
 mod buf_impl;
 mod buf_mut;
 mod iter;
+mod pool;
 mod uninit_slice;
 mod writer;
 
 pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
 pub use self::iter::IntoIter;
+pub use self::pool::{
+	BufferAccumulator, BufferPool, BufferSink, BufferSource,
+	BytesAccumulator, BytesPool,
+	Owned, Shared,
+};
 pub use self::uninit_slice::UninitSlice;
 pub use self::writer::Writer;

--- a/ntex-bytes/src/buf/pool.rs
+++ b/ntex-bytes/src/buf/pool.rs
@@ -1,0 +1,269 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut, buf::UninitSlice};
+use std::future::{self, Future};
+use std::io::IoSlice;
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// A source of buffers.
+///
+/// Dropped buffers will automatically return to this pool.
+pub trait BufferSource {
+    /// The type of buffer returned by this buffer source that owns its contents.
+    type Owned: Owned;
+
+    /// The type of accumulator of buffers used by encoders.
+    type Accumulator: BufferAccumulator<Shared = <Self::Owned as Owned>::Shared>;
+
+    /// The type of future returned by the [`BufferSource::take`] impl.
+    type TakeFuture: Future<Output = Self::Owned>;
+
+    /// Asynchronously returns a buffer that is at least as long as the requested length.
+    fn take(&self, len: usize) -> Self::TakeFuture;
+}
+
+impl<T> BufferSource for &'_ T where T: BufferSource {
+    type Owned = T::Owned;
+    type Accumulator = T::Accumulator;
+    type TakeFuture = T::TakeFuture;
+
+    fn take(&self, len: usize) -> Self::TakeFuture {
+        (**self).take(len)
+    }
+}
+
+/// A sink of buffers. Dropped buffers will automatically return to this sink.
+pub trait BufferSink {
+    /// The type of buffer returned by this buffer source that owns its contents.
+    type Owned: Owned;
+
+    /// The type of backing buffer that is returned to this pool when the last owned or shared buffer
+    /// holding on to said backing buffer is dropped.
+    type Backing;
+
+    /// Returns the given backing buffer to the pool. This is intended to be invoked from
+    /// the `Drop` impls of this pool's owned and shared buffer types.
+    fn put_back(&self, backing: Self::Backing);
+}
+
+/// Convenience trait for a type that is a buffer pool, ie a type that is both a [`BufferSource`]
+/// and a [`BufferSink`].
+pub trait BufferPool: BufferSource + BufferSink<Owned = <Self as BufferSource>::Owned> {}
+
+impl<T> BufferPool for T where T: BufferSource + BufferSink<Owned = <Self as BufferSource>::Owned> {}
+
+impl<T> BufferSink for Rc<T>
+where
+    T: ?Sized + BufferSink,
+{
+    type Backing = T::Backing;
+    type Owned = T::Owned;
+
+    fn put_back(&self, backing: Self::Backing) {
+        (&**self).put_back(backing);
+    }
+}
+
+impl<T> BufferSink for Arc<T>
+where
+    T: BufferSink,
+{
+    type Backing = T::Backing;
+    type Owned = T::Owned;
+
+    fn put_back(&self, backing: Self::Backing) {
+        (&**self).put_back(backing);
+    }
+}
+
+/// A [`BufferSource`] that always yields new `BytesMut` without blocking.
+#[derive(Clone, Copy, Debug)]
+pub struct BytesPool;
+
+impl BufferSource for BytesPool {
+    type Owned = BytesMut;
+    type Accumulator = BytesAccumulator;
+    type TakeFuture = future::Ready<Self::Owned>;
+
+    fn take(&self, len: usize) -> Self::TakeFuture {
+        future::ready(BytesMut::with_capacity(len))
+    }
+}
+
+impl BufferSink for BytesPool {
+    type Backing = ();
+    type Owned = <Self as BufferSource>::Owned;
+
+    fn put_back(&self, _backing: Self::Backing) {
+    }
+}
+
+/// A buffer that owns a particular range of its backing buffer.
+///
+/// An `Owned` tracks what part of itself has been filled with data.
+/// The filled region can be accessed with [`Owned::filled`].
+/// The unfilled region can be accessed with [`Owned::unfilled_mut`], and bytes can be moved from the start of this region
+/// into the end of the filled region with [`Owned::fill`].
+///
+/// An `Owned` can be subdivided into smaller `Owned`s with `split_to` that each own
+/// smaller splits of the backing buffer.
+///
+/// An `Owned` is not `Clone`. It can be converted to a [`Shared`] which is, via [`Owned::freeze`]
+pub trait Owned {
+    /// The type of shared buffers with the same backing buffer.
+    type Shared: Shared;
+
+    /// Try to append a `u8` to this buffer's filled region.
+    ///
+    /// Returns `None` if there is no space in the filled region to append this `u8`.
+    fn try_put_u8(&mut self, n: u8) -> Option<()> {
+        self.try_put_slice(&[n])
+    }
+
+    /// Try to append a `u16` in big-endian order to this buffer's filled region.
+    ///
+    /// Returns `None` if there is no space in the filled region to append this `u16`.
+    fn try_put_u16_be(&mut self, n: u16) -> Option<()> {
+        self.try_put_slice(&n.to_be_bytes())
+    }
+
+    /// Try to append a `u32` in big-endian order to this buffer's filled region.
+    ///
+    /// Returns `None` if there is no space in the filled region to append this `u32`.
+    fn try_put_u32_be(&mut self, n: u32) -> Option<()> {
+        self.try_put_slice(&n.to_be_bytes())
+    }
+
+    /// Try to append a slice in big-endian order to this buffer's filled region.
+    ///
+    /// Returns `None` if there is no space in the filled region to append this slice.
+    fn try_put_slice(&mut self, src: &[u8]) -> Option<()>;
+
+    /// Returns the filled region of this buffer.
+    fn filled(&self) -> &[u8];
+
+    /// Returns whether the filled region of this buffer is empty or not.
+    fn filled_is_empty(&self) -> bool {
+        self.filled().is_empty()
+    }
+
+    /// Retains the range `i..` in `self`, and returns a new `Owned` for the range `0..i`
+    fn split_to(&mut self, i: usize) -> Self;
+
+    /// Returns the unfilled region of this buffer.
+    fn unfilled_mut(&mut self) -> &mut UninitSlice;
+
+    /// Moves the given number of bytes from the start of the unfilled region to the end of the filled region.
+    unsafe fn fill(&mut self, n: usize);
+}
+
+/// A buffer that has a shared reference to a particular range of its backing buffer.
+pub trait Shared: AsRef<[u8]> + Deref<Target = [u8]> {
+}
+
+impl Owned for BytesMut {
+    type Shared = Bytes;
+
+    fn try_put_slice(&mut self, src: &[u8]) -> Option<()> {
+        self.extend_from_slice(src);
+        Some(())
+    }
+
+    fn filled(&self) -> &[u8] {
+        Buf::chunk(self)
+    }
+
+    fn split_to(&mut self, i: usize) -> Self {
+        self.split_to(i)
+    }
+
+    fn unfilled_mut(&mut self) -> &mut UninitSlice {
+        BufMut::chunk_mut(self)
+    }
+
+    /// Moves the given number of bytes from the start of the unfilled region to the end of the filled region.
+    unsafe fn fill(&mut self, n: usize) {
+        BufMut::advance_mut(self, n);
+    }
+}
+
+impl Shared for Bytes {
+}
+
+/// An accumulator that collects buffers.
+///
+/// This is used by encoders that need to make a collection of smaller chunks out of each item they wish to encode.
+pub trait BufferAccumulator {
+    /// The type of shared buffers that can be appended to this accumulator.
+    type Shared: Shared;
+
+    /// Constructs a new, empty accumulator with the specified capacity (in bytes).
+    fn with_capacity(capacity: usize) -> Self;
+
+    /// Append a `Self::Shared` to this accumulator.
+    ///
+    /// Returns `None` if appending fails for any reason.
+    fn put_bytes(&mut self, src: Self::Shared) -> Option<()>;
+
+    /// Returns whether this accumulator has no bytes in it or not.
+    fn is_empty(&self) -> bool;
+
+    /// Returns whether this accumulator can accept more bytes or not.
+    fn is_full(&self) -> bool;
+
+    /// Returns the first (and possibly only) chunk from this accumulator.
+    ///
+    /// Returns `None` if this accumulator is empty.
+    fn chunk(&self) -> &[u8];
+
+    /// Fills as many chunks from this accumulator as possible into the given [`IoSlice`]s slice.
+    ///
+    /// Returns the number of chunks set to valid data in `dst`.
+    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize;
+
+    /// Drops `cnt` bytes from the front of this accumulator.
+    fn advance(&mut self, cnt: usize);
+}
+
+/// An [`Accumulator`] around an inner [`BytesMut`].
+#[derive(Debug)]
+pub struct BytesAccumulator {
+    inner: BytesMut,
+    initial_capacity: usize,
+}
+
+impl BufferAccumulator for BytesAccumulator {
+    type Shared = Bytes;
+
+    fn with_capacity(capacity: usize) -> Self {
+        BytesAccumulator {
+            inner: BytesMut::with_capacity(capacity),
+            initial_capacity: capacity,
+        }
+    }
+
+    fn put_bytes(&mut self, src: Self::Shared) -> Option<()> {
+        self.inner.extend_from_slice(&src);
+        Some(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    fn is_full(&self) -> bool {
+        self.inner.len() >= self.initial_capacity
+    }
+
+    fn chunk(&self) -> &[u8] {
+        Buf::chunk(&self.inner)
+    }
+
+    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+        Buf::chunks_vectored(&self.inner, dst)
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        Buf::advance(&mut self.inner, cnt);
+    }
+}

--- a/ntex-bytes/src/lib.rs
+++ b/ntex-bytes/src/lib.rs
@@ -66,6 +66,11 @@ mod debug;
 mod hex;
 mod string;
 
+pub use self::buf::{
+    BufferAccumulator, BufferPool, BufferSink, BufferSource,
+    BytesAccumulator, BytesPool,
+    Owned, Shared,
+};
 pub use crate::bytes::{Bytes, BytesMut};
 pub use crate::string::ByteString;
 

--- a/ntex-codec/Cargo.toml
+++ b/ntex-codec/Cargo.toml
@@ -17,11 +17,12 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.3"
-ntex-bytes = "0.1"
-ntex-util = "0.1"
+futures-util = { version = "0.3", default-features = false }
+ntex-bytes = { version = "0.1", path = "../ntex-bytes/" }
+ntex-util = { version = "0.1", path = "../ntex-util/" }
 log = "0.4"
 tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
-ntex = "0.3.13"
+ntex = { version = "0.4", path = "../ntex/" }
 futures = "0.3.13"

--- a/ntex-codec/src/lib.rs
+++ b/ntex-codec/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`AsyncRead`]: #
 //! [`AsyncWrite`]: #
 #![deny(rust_2018_idioms, warnings)]
-use std::{io, mem::MaybeUninit, pin::Pin, task::Context, task::Poll};
+use std::{io, mem::MaybeUninit, pin::Pin, task::Poll};
 
 mod bcodec;
 mod decoder;
@@ -21,35 +21,53 @@ pub use self::framed::{Framed, FramedParts};
 
 pub use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use ntex_bytes::{BufMut, BytesMut};
+use ntex_bytes::{BufferSource, Owned};
 
-pub fn poll_read_buf<T: AsyncRead>(
-    io: Pin<&mut T>,
-    cx: &mut Context<'_>,
-    buf: &mut BytesMut,
-) -> Poll<io::Result<usize>> {
-    if !buf.has_remaining_mut() {
-        return Poll::Ready(Ok(0));
+pub async fn read_buf<T: AsyncRead, P: BufferSource>(
+    mut io: Pin<&mut T>,
+    buf: &mut P::Owned,
+    pool: P,
+    min_capacity: usize,
+) -> io::Result<usize> {
+    let remaining = buf.unfilled_mut().len();
+    if remaining == 0 {
+        let src = buf.filled();
+
+        let num_bytes_to_copy_over = buf.filled().len();
+        let new_len = std::cmp::max(min_capacity, num_bytes_to_copy_over * 2);
+        let mut new_buf = pool.take(new_len).await;
+
+        let dst = new_buf.unfilled_mut();
+        assert!(dst.len() > num_bytes_to_copy_over);
+        unsafe {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len());
+            new_buf.fill(num_bytes_to_copy_over);
+        }
+
+        *buf = new_buf;
     }
 
-    let n = {
-        let dst = unsafe { &mut *(buf.chunk_mut() as *mut _ as *mut [MaybeUninit<u8>]) };
+    let n = futures_util::future::poll_fn(|cx| {
+        let dst = unsafe { &mut *(buf.unfilled_mut() as *mut _ as *mut [MaybeUninit<u8>]) };
         let mut buf = ReadBuf::uninit(dst);
+
         let ptr = buf.filled().as_ptr();
-        if io.poll_read(cx, &mut buf)?.is_pending() {
+
+        if io.as_mut().poll_read(cx, &mut buf)?.is_pending() {
             return Poll::Pending;
         }
 
         // Ensure the pointer does not change from under us
         assert_eq!(ptr, buf.filled().as_ptr());
-        buf.filled().len()
-    };
+
+        Poll::Ready(Ok::<_, io::Error>(buf.filled().len()))
+    }).await?;
 
     // Safety: This is guaranteed to be the number of initialized (and read)
     // bytes due to the invariants provided by `ReadBuf::filled`.
     unsafe {
-        buf.advance_mut(n);
+        buf.fill(n);
     }
 
-    Poll::Ready(Ok(n))
+    Ok(n)
 }

--- a/ntex-rt/Cargo.toml
+++ b/ntex-rt/Cargo.toml
@@ -16,6 +16,6 @@ name = "ntex_rt"
 path = "src/lib.rs"
 
 [dependencies]
-ntex-util = "0.1.0"
+ntex-util = { version = "0.1.0", path = "../ntex-util" }
 pin-project-lite = "0.2"
 tokio = { version = "1", default-features = false, features = ["rt", "net", "time", "signal", "sync"] }

--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -43,13 +43,13 @@ http-framework = ["h2", "http", "httparse",
     "httpdate", "encoding_rs", "mime", "percent-encoding", "serde_json", "serde_urlencoded"]
 
 [dependencies]
-ntex-codec = "0.5.1"
-ntex-rt = "0.3.1"
-ntex-router = "0.5.1"
-ntex-service = "0.2.1"
-ntex-macros = "0.1.3"
-ntex-util = "0.1.1"
-ntex-bytes = "0.1.4"
+ntex-codec = { version = "0.5.1", path = "../ntex-codec/" }
+ntex-rt = { version = "0.3.1", path = "../ntex-rt/" }
+ntex-router = { version = "0.5.1", path = "../ntex-router/" }
+ntex-service = { version = "0.2.1", path = "../ntex-service/" }
+ntex-macros = { version = "0.1.3", path = "../ntex-macros/" }
+ntex-util = { version = "0.1.1", path = "../ntex-util/" }
+ntex-bytes = { version = "0.1.4", path = "../ntex-bytes/" }
 
 base64 = "0.13"
 bitflags = "1.3"

--- a/ntex/src/util/mod.rs
+++ b/ntex/src/util/mod.rs
@@ -10,7 +10,12 @@ pub mod variant;
 
 pub use self::extensions::Extensions;
 
-pub use ntex_bytes::{Buf, BufMut, ByteString, Bytes, BytesMut};
+pub use ntex_bytes::{
+	Buf, BufMut,
+	ByteString,
+	Bytes, BytesMut,
+	BufferPool, BytesPool,
+};
 pub use ntex_util::future::*;
 
 pub type HashMap<K, V> = std::collections::HashMap<K, V, fxhash::FxBuildHasher>;


### PR DESCRIPTION
(This is still a WIP change and not ready to be merged. I'm opening this PR
to discuss the changes to ntex-bytes and ntex-codec while I work on ntex and
ntex-mqtt.)

ntex-bytes now has two new traits, BufferSource and BufferSink.
A BufferSource is a way to asynchronously receive a buffer of a minimum
requested size. Such a buffer internally holds on to a reference to
a BufferSink, such that when the buffer is Drop'd it'll automatically return
itself to the sink. The source and sink will normally be the same type; they're
split up into two different traits because some parts of the stack only care
about sources (eg encoders) and others only about sinks (eg decoders and
frames). There is a trait alias BufferPool for BufferSource + BufferSink
for convenience.

A BufferPool deals with two types of buffers, owned and shared buffers.
An owned buffer implements the Owned trait and is generally equivalent to
bytes::BytesMut - it is the sole owner of a range of contiguous bytes and thus
provides mutable access to those bytes, along with a read and write cursor
to mark what subset of the range contains readable bytes. An owned buffer
can be split into smaller owned buffers with split_to, and can be frozen into
a shared buffer with freeze. A shared buffer implements the Shared trait and
is generally equivalent to bytes::Bytes - it is not necessarily the sole owner
of the range of bytes and thus can only provide readonly access.

Unlike BytesMut, an Owned has no requirement of being able to grow to fit more
bytes in it than it has the capacity for. Also, by allowing the types to be
externally pluggable, it allows users like us to use more optimized types for
our use case, such as types that do not have an internal vtable to switch
between Vec/Arc backing implementations, especially when such switching
involves memcpy'ing.

Lastly, a buffer pool has a third associated type called an accumulator that
implements the BytesAccumulator trait. This trait is intended to be used by
Encoders and is a sink for Shared buffers. Unlike a BytesMut that can only
merge Bytes into itself by copying them, a BytesAccumulator implementation
might choose to maintain a Vec<Shared>-like rope structure that can be used
with vectored writes.

Because the pool needs to be threaded through codecs and servers, many types
now have an additional type parameter P for the pool type. As Nikolay had
requested, there is a default pool whose Owned and Accumulator are BytesMut and
whose Shared is Bytes - ntex_bytes::BytesPool - and the type parameter
defaults to this pool. However, there are still API changes to account for
the fact that receiving a buffer from the pool is asynchronous.

- ntex_codec::Encoder::encode now takes a pool and an accumulator instead of
  a BytesMut, and returns a Future of the encoding result instead of the result
  directly.

- As a consequence ntex_codec::Framed::encode is also asynchronous.

- ntex_codec::Framed::encode now supports using vectored write when encoding, if
  the IO type and the BytesAccumulator support it.

- ntex_codec::Framed::next_item is now asynchronous.

- ntex_codec::Framed no longer impl Stream and Sink. I've deleted these impls
  for now. The alternative would be to add newtype wrappers that hold on to
  the intermediate futures from ::encode and ::next_item.

Other changes:

- Dependencies on other ntex- crates in the same repo now use both
  `version = "..."` and `path = "../..."`. This allows testing local changes.