### PR TITLE
add socket options

### DIFF
--- a/ntex-tokio/src/lib.rs
+++ b/ntex-tokio/src/lib.rs
@@ -6,7 +6,7 @@ use ntex_io::Io;
 mod io;
 mod signals;
 
-pub use self::io::TokioIoBoxed;
+pub use self::io::{SocketOptions, TokioIoBoxed};
 pub use self::signals::{signal, Signal};
 
 struct TcpStream(tokio::net::TcpStream);


### PR DESCRIPTION
add ability to change socket options for tokio.

this is useful for niche use cases and for testing (i.e. forcing a tcp reset). setting linger to 0 is special case on unix  to reset connection, but we must elide the call to shutdown in this case.