### PR TITLE
Implement std::error::Error and fix minor issues

### DIFF
--- a/ntex-bytes/src/bytes.rs
+++ b/ntex-bytes/src/bytes.rs
@@ -766,7 +766,7 @@ impl Bytes {
     ///
     /// assert_eq!(&a[..4], b"bary");
     /// ```
-    pub fn try_mut(mut self) -> Result<BytesMut, Bytes> {
+    pub fn try_mut(self) -> Result<BytesMut, Bytes> {
         if self.inner.is_mut_safe() {
             Ok(BytesMut { inner: self.inner })
         } else {
@@ -1888,8 +1888,8 @@ impl Inner {
     fn from_slice(cap: usize, src: &[u8], pool: PoolRef) -> Inner {
         // Store data in vec
         let mut vec = Vec::with_capacity(cap + SHARED_VEC_SIZE);
+        #[allow(clippy::uninit_vec)]
         unsafe {
-            #![allow(clippy::unit_arg)]
             vec.set_len(SHARED_VEC_SIZE);
             vec.extend_from_slice(src);
 
@@ -2252,7 +2252,7 @@ impl Inner {
     }
 
     /// Checks if it is safe to mutate the memory
-    fn is_mut_safe(&mut self) -> bool {
+    fn is_mut_safe(&self) -> bool {
         let kind = self.kind();
 
         // Always check `inline` first, because if the handle is using inline
@@ -2446,7 +2446,7 @@ impl Inner {
 
     /// Used for `debug_assert` statements
     #[inline]
-    fn is_static(&mut self) -> bool {
+    fn is_static(&self) -> bool {
         matches!(self.kind(), KIND_STATIC)
     }
 

--- a/ntex-bytes/src/bytes.rs
+++ b/ntex-bytes/src/bytes.rs
@@ -1889,7 +1889,7 @@ impl Inner {
         // Store data in vec
         let mut vec = Vec::with_capacity(cap + SHARED_VEC_SIZE);
         unsafe {
-            #![allow(clippy::uninit_vec)]
+            #![allow(clippy::unit_arg)]
             vec.set_len(SHARED_VEC_SIZE);
             vec.extend_from_slice(src);
 

--- a/ntex-bytes/src/lib.rs
+++ b/ntex-bytes/src/lib.rs
@@ -56,7 +56,6 @@
 //    missing_debug_implementations,
     rust_2018_idioms
 )]
-#![allow(clippy::return_self_not_must_use)]
 #![doc(html_root_url = "https://docs.rs/ntex-bytes/")]
 
 pub mod buf;

--- a/ntex-bytes/tests/test_bytes.rs
+++ b/ntex-bytes/tests/test_bytes.rs
@@ -3,8 +3,8 @@ use std::task::Poll;
 
 use ntex_bytes::{Buf, BufMut, Bytes, BytesMut, PoolId};
 
-const LONG: &'static [u8] = b"mary had a little lamb, little lamb, little lamb";
-const SHORT: &'static [u8] = b"hello world";
+const LONG: &[u8] = b"mary had a little lamb, little lamb, little lamb";
+const SHORT: &[u8] = b"hello world";
 
 fn inline_cap() -> usize {
     use std::mem;
@@ -267,7 +267,7 @@ fn split_off_to_loop() {
 #[test]
 fn split_to_1() {
     // Inline
-    let mut a = Bytes::from(&SHORT[..]);
+    let mut a = Bytes::from(SHORT);
     let b = a.split_to(4);
 
     assert_eq!(SHORT[4..], a);
@@ -568,7 +568,7 @@ fn from_iter_no_size_hint() {
 
 fn test_slice_ref(bytes: &Bytes, start: usize, end: usize, expected: &[u8]) {
     let slice = &(bytes.as_ref()[start..end]);
-    let sub = bytes.slice_ref(&slice);
+    let sub = bytes.slice_ref(slice);
     assert_eq!(&sub[..], expected);
 }
 
@@ -588,7 +588,7 @@ fn slice_ref_empty() {
     let bytes = Bytes::from(&b""[..]);
     let slice = &(bytes.as_ref()[0..0]);
 
-    let sub = bytes.slice_ref(&slice);
+    let sub = bytes.slice_ref(slice);
     assert_eq!(&sub[..], b"");
 }
 

--- a/ntex-io/src/dispatcher.rs
+++ b/ntex-io/src/dispatcher.rs
@@ -491,7 +491,7 @@ mod tests {
             let state = Io::new(io);
             let ka_timeout = Cell::new(Seconds(1).into());
             let shared = Rc::new(DispatcherShared {
-                codec: codec,
+                codec,
                 error: Cell::new(None),
                 inflight: Cell::new(0),
             });

--- a/ntex-io/src/ioref.rs
+++ b/ntex-io/src/ioref.rs
@@ -421,7 +421,7 @@ mod tests {
             let in_bytes = self.1.clone();
             let out_bytes = self.2.clone();
             let read_order = self.3.clone();
-            let write_order = self.4.clone();
+            let write_order = self.4;
             Ready::Ok(
                 io.map_filter(|inner| {
                     Ok::<_, ()>(Counter {

--- a/ntex-io/src/lib.rs
+++ b/ntex-io/src/lib.rs
@@ -1,5 +1,4 @@
 //! Utilities for abstructing io streams
-#![allow(clippy::return_self_not_must_use)]
 use std::{
     any::Any, any::TypeId, fmt, future::Future, io as sio, io::Error as IoError,
     task::Context, task::Poll,

--- a/ntex-rt/src/lib.rs
+++ b/ntex-rt/src/lib.rs
@@ -1,6 +1,4 @@
 //! A runtime implementation that runs everything on the current thread.
-#![allow(clippy::return_self_not_must_use)]
-
 mod arbiter;
 mod builder;
 mod system;

--- a/ntex-tls/src/lib.rs
+++ b/ntex-tls/src/lib.rs
@@ -1,5 +1,4 @@
 //! An implementations of SSL streams for ntex ecosystem
-#![allow(clippy::return_self_not_must_use)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub mod types;

--- a/ntex-util/src/lib.rs
+++ b/ntex-util/src/lib.rs
@@ -1,5 +1,4 @@
 //! Utilities for ntex framework
-#![allow(clippy::return_self_not_must_use)]
 pub mod channel;
 pub mod future;
 pub mod services;

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -321,7 +321,7 @@ mod tests {
         });
 
         let srv = apply(
-            Buffer::new(|| ()).buf_size(2).clone(),
+            Buffer::new(|| ()).buf_size(2),
             fn_factory(|| async { Ok::<_, ()>(TestService(inner.clone())) }),
         );
 

--- a/ntex-util/src/services/timeout.rs
+++ b/ntex-util/src/services/timeout.rs
@@ -52,9 +52,8 @@ impl<E: fmt::Display> fmt::Display for TimeoutError<E> {
     }
 }
 
-impl<E: fmt::Display + fmt::Debug> std::error::Error for TimeoutError<E> {
+impl<E: fmt::Display + fmt::Debug> std::error::Error for TimeoutError<E> {}
 
-}
 impl<E: PartialEq> PartialEq for TimeoutError<E> {
     fn eq(&self, other: &TimeoutError<E>) -> bool {
         match self {

--- a/ntex-util/src/services/timeout.rs
+++ b/ntex-util/src/services/timeout.rs
@@ -52,6 +52,9 @@ impl<E: fmt::Display> fmt::Display for TimeoutError<E> {
     }
 }
 
+impl<E: fmt::Display + fmt::Debug> std::error::Error for TimeoutError<E> {
+
+}
 impl<E: PartialEq> PartialEq for TimeoutError<E> {
     fn eq(&self, other: &TimeoutError<E>) -> bool {
         match self {

--- a/ntex-util/src/services/variant.rs
+++ b/ntex-util/src/services/variant.rs
@@ -346,7 +346,7 @@ mod tests {
             .v2(fn_factory(|| async { Ok::<_, ()>(Srv2) }))
             .v3(fn_factory(|| async { Ok::<_, ()>(Srv2) }))
             .clone();
-        let service = factory.new_service(&()).await.clone().unwrap();
+        let service = factory.new_service(&()).await.unwrap();
 
         assert!(lazy(|cx| service.poll_ready(cx)).await.is_ready());
         assert!(lazy(|cx| service.poll_shutdown(cx, true)).await.is_ready());

--- a/ntex/src/http/body.rs
+++ b/ntex/src/http/body.rs
@@ -514,7 +514,7 @@ mod tests {
     impl Body {
         pub(crate) fn get_ref(&self) -> &[u8] {
             match *self {
-                Body::Bytes(ref bin) => &bin,
+                Body::Bytes(ref bin) => bin,
                 _ => panic!(),
             }
         }

--- a/ntex/src/http/error.rs
+++ b/ntex/src/http/error.rs
@@ -233,6 +233,8 @@ pub enum ContentTypeError {
     Expected,
 }
 
+impl std::error::Error for ContentTypeError {}
+
 /// Blocking operation execution error
 #[derive(Debug, Display)]
 pub enum BlockingError<E: fmt::Debug> {

--- a/ntex/src/http/h1/decoder.rs
+++ b/ntex/src/http/h1/decoder.rs
@@ -1213,8 +1213,8 @@ mod tests {
     #[test]
     fn test_parse_chunked_payload_chunk_extension() {
         let mut buf = BytesMut::from(
-            &"GET /test HTTP/1.1\r\n\
-              transfer-encoding: chunked\r\n\r\n"[..],
+            "GET /test HTTP/1.1\r\n\
+              transfer-encoding: chunked\r\n\r\n",
         );
 
         let reader = MessageDecoder::<Request>::default();
@@ -1233,7 +1233,7 @@ mod tests {
 
     #[test]
     fn test_response_http10_read_until_eof() {
-        let mut buf = BytesMut::from(&"HTTP/1.0 200 Ok\r\n\r\ntest data"[..]);
+        let mut buf = BytesMut::from("HTTP/1.0 200 Ok\r\n\r\ntest data");
 
         let reader = MessageDecoder::<ResponseHead>::default();
         let (_msg, pl) = reader.decode(&mut buf).unwrap().unwrap();

--- a/ntex/src/lib.rs
+++ b/ntex/src/lib.rs
@@ -18,8 +18,7 @@
     clippy::borrow_interior_mutable_const,
     clippy::needless_doctest_main,
     clippy::too_many_arguments,
-    clippy::new_without_default,
-    clippy::return_self_not_must_use
+    clippy::new_without_default
 )]
 
 #[macro_use]

--- a/ntex/src/web/error.rs
+++ b/ntex/src/web/error.rs
@@ -27,8 +27,7 @@ pub trait ErrorContainer: error::ResponseError + Sized {
 }
 
 /// Error that can be rendered to a `Response`
-pub trait WebResponseError<Err = DefaultError>:
-    fmt::Debug + fmt::Display + 'static
+pub trait WebResponseError<Err = DefaultError>: std::error::Error + 'static
 where
     Err: ErrorRenderer,
 {
@@ -84,6 +83,8 @@ pub enum DataExtractorError {
     NotConfigured,
 }
 
+impl std::error::Error for DataExtractorError {}
+
 /// Errors which can occur when attempting to generate resource uri.
 #[derive(Debug, PartialEq, Display, From)]
 pub enum UrlGenerationError {
@@ -98,6 +99,8 @@ pub enum UrlGenerationError {
     #[display(fmt = "{}", _0)]
     ParseError(UrlParseError),
 }
+
+impl std::error::Error for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
 #[derive(Debug, Display, From)]
@@ -126,6 +129,8 @@ pub enum UrlencodedError {
     Payload(error::PayloadError),
 }
 
+impl std::error::Error for UrlencodedError {}
+
 /// A set of errors that can occur during parsing json payloads
 #[derive(Debug, Display, From)]
 pub enum JsonPayloadError {
@@ -143,6 +148,8 @@ pub enum JsonPayloadError {
     Payload(error::PayloadError),
 }
 
+impl std::error::Error for JsonPayloadError {}
+
 /// A set of errors that can occur during parsing request paths
 #[derive(Debug, Display, From)]
 pub enum PathError {
@@ -151,6 +158,8 @@ pub enum PathError {
     Deserialize(serde::de::value::Error),
 }
 
+impl std::error::Error for PathError {}
+
 /// A set of errors that can occur during parsing query strings
 #[derive(Debug, Display, From)]
 pub enum QueryPayloadError {
@@ -158,6 +167,8 @@ pub enum QueryPayloadError {
     #[display(fmt = "Query deserialize error: {}", _0)]
     Deserialize(serde::de::value::Error),
 }
+
+impl std::error::Error for QueryPayloadError {}
 
 #[derive(Debug, Display, From)]
 pub enum PayloadError {
@@ -171,6 +182,8 @@ pub enum PayloadError {
     #[display(fmt = "Cannot decode body")]
     Decoding,
 }
+
+impl std::error::Error for PayloadError {}
 
 /// Helper type that can wrap any error and generate custom response.
 ///
@@ -244,6 +257,8 @@ where
         fmt::Display::fmt(&self.cause, f)
     }
 }
+
+impl<T: fmt::Display + fmt::Debug + 'static, E> std::error::Error for InternalError<T, E> {}
 
 impl<T, E> WebResponseError<E> for InternalError<T, E>
 where

--- a/ntex/src/web/error.rs
+++ b/ntex/src/web/error.rs
@@ -27,7 +27,8 @@ pub trait ErrorContainer: error::ResponseError + Sized {
 }
 
 /// Error that can be rendered to a `Response`
-pub trait WebResponseError<Err = DefaultError>: std::error::Error + 'static
+pub trait WebResponseError<Err = DefaultError>:
+    fmt::Display + fmt::Debug + 'static
 where
     Err: ErrorRenderer,
 {

--- a/ntex/src/web/types/query.rs
+++ b/ntex/src/web/types/query.rs
@@ -1,5 +1,4 @@
 //! Query extractor
-
 use std::{fmt, ops};
 
 use serde::de;
@@ -163,10 +162,10 @@ mod tests {
     #[crate::rt_test]
     async fn test_service_request_extract() {
         let req = TestRequest::with_uri("/name/user1/").to_srv_request();
-        assert!(Query::<Id>::from_query(&req.query_string()).is_err());
+        assert!(Query::<Id>::from_query(req.query_string()).is_err());
 
         let req = TestRequest::with_uri("/name/user1/?id=test").to_srv_request();
-        let mut s = Query::<Id>::from_query(&req.query_string()).unwrap();
+        let mut s = Query::<Id>::from_query(req.query_string()).unwrap();
 
         assert_eq!(s.id, "test");
         assert_eq!(format!("{}, {:?}", s, s), "test, Id { id: \"test\" }");

--- a/ntex/src/ws/error.rs
+++ b/ntex/src/ws/error.rs
@@ -150,6 +150,8 @@ pub enum HandshakeError {
     BadWebsocketKey,
 }
 
+impl std::error::Error for HandshakeError {}
+
 impl ResponseError for HandshakeError {
     fn error_response(&self) -> Response {
         match *self {

--- a/ntex/tests/web_server.rs
+++ b/ntex/tests/web_server.rs
@@ -1094,6 +1094,7 @@ async fn test_slow_request() {
 async fn test_custom_error() {
     #[derive(Debug, Display)]
     struct TestError;
+    impl std::error::Error for TestError {}
 
     #[derive(Debug, Display)]
     struct JsonContainer(Box<dyn WebResponseError<JsonRenderer>>);


### PR DESCRIPTION
Errors would be better implemented with `thiserror` instead of `derive_more`. I implement it? 