### PR TITLE
feat: allow extracting TLS SNI server name and TLS PSK identity

### DIFF
--- a/ntex-tls/Cargo.toml
+++ b/ntex-tls/Cargo.toml
@@ -32,7 +32,7 @@ ntex-service = "0.3.1"
 pin-project-lite = "0.2"
 
 # openssl
-tls_openssl = { version="0.10", package = "openssl", optional = true }
+tls_openssl = { version="0.10.42", package = "openssl", optional = true }
 
 # rustls
 tls_rust = { version = "0.20", package = "rustls", optional = true }

--- a/ntex-tls/src/lib.rs
+++ b/ntex-tls/src/lib.rs
@@ -28,3 +28,15 @@ static MAX_SSL_ACCEPT: AtomicUsize = AtomicUsize::new(256);
 thread_local! {
     static MAX_SSL_ACCEPT_COUNTER: counter::Counter = counter::Counter::new(MAX_SSL_ACCEPT.load(Ordering::Relaxed));
 }
+
+/// A TLS PSK identity.
+///
+/// Used in conjunction with [`ntex_io::Filter::query`]:
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PskIdentity(pub Vec<u8>);
+
+/// The TLS SNI server name (DNS).
+///
+/// Used in conjunction with [`ntex_io::Filter::query`]:
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Servername(pub String);

--- a/ntex-tls/src/rustls/server.rs
+++ b/ntex-tls/src/rustls/server.rs
@@ -8,6 +8,7 @@ use ntex_util::{future::poll_fn, ready, time, time::Millis};
 use tls_rust::{ServerConfig, ServerConnection};
 
 use crate::rustls::{IoInner, TlsFilter, Wrapper};
+use crate::Servername;
 
 use super::{PeerCert, PeerCertChain};
 
@@ -48,6 +49,12 @@ impl<F: Filter> Filter for TlsServerFilter<F> {
         } else if id == any::TypeId::of::<PeerCertChain>() {
             if let Some(cert_chain) = self.session.borrow().peer_certificates() {
                 Some(Box::new(PeerCertChain(cert_chain.to_vec())))
+            } else {
+                None
+            }
+        } else if id == any::TypeId::of::<Servername>() {
+            if let Some(name) = self.session.borrow().sni_hostname() {
+                Some(Box::new(Servername(name.to_string())))
             } else {
                 None
             }


### PR DESCRIPTION
This change allows to query for the SNI server name and the PSK identity.

The server name implements only the DNS variant, as this is what both APIs currently seem to support.

The PSK identity is only implemented for OpenSSL, as RustTLS currently doesn't support TLS PSK. But it could be implemented the same way, once this becomes available.