### PR TITLE
Create the correct PskIdentity type on query

### DIFF
--- a/ntex-tls/src/openssl/mod.rs
+++ b/ntex-tls/src/openssl/mod.rs
@@ -113,7 +113,7 @@ impl<F: Filter> Filter for SslFilter<F> {
             }
         } else if id == any::TypeId::of::<PskIdentity>() {
             if let Some(psk_id) = self.inner.borrow().ssl().psk_identity() {
-                Some(Box::new(psk_id.to_vec()))
+                Some(Box::new(PskIdentity(psk_id.to_vec())))
             } else {
                 None
             }


### PR DESCRIPTION
A bug in the newly added PskIdentity query handling where it stores the Vec<u8> instead of PskIdentity(Vec<u8>) inside the query item.

CC @ctron 