### PR TITLE
Fix compilation errors in the openwrt environment

### DIFF
--- a/ntex-io/src/io.rs
+++ b/ntex-io/src/io.rs
@@ -753,14 +753,14 @@ struct FilterItem<F> {
 impl<F> FilterItem<F> {
     fn null() -> Self {
         Self {
-            data: [0; 16],
+            data: [0; SEALED_SIZE],
             _t: marker::PhantomData,
         }
     }
 
     fn with_filter(f: Box<F>) -> Self {
         let mut slf = Self {
-            data: [0; 16],
+            data: [0; SEALED_SIZE],
             _t: marker::PhantomData,
         };
 
@@ -774,7 +774,7 @@ impl<F> FilterItem<F> {
 
     fn with_sealed(f: Sealed) -> Self {
         let mut slf = Self {
-            data: [0; 16],
+            data: [0; SEALED_SIZE],
             _t: marker::PhantomData,
         };
 


### PR DESCRIPTION

Fix compilation errors in the openwrt environment : 
```
error[E0308]: mismatched types
   --> /home/rust/ntex/ntex-io/src/io.rs:756:19
    |
756 |             data: [0; 16],
    |                   ^^^^^^^ expected an array with a fixed size of 8 elements, found one with 16 elements

```