### PR TITLE
Update ntex-service documentation

### DIFF
--- a/ntex-service/src/apply.rs
+++ b/ntex-service/src/apply.rs
@@ -2,7 +2,7 @@ use std::{future::Future, marker::PhantomData, pin::Pin, task::Context, task::Po
 
 use super::{IntoService, IntoServiceFactory, Service, ServiceFactory};
 
-/// Apply tranform function to a service.
+/// Apply transform function to a service.
 pub fn apply_fn<T, Req, F, R, In, Out, Err, U>(
     service: U,
     f: F,
@@ -16,7 +16,7 @@ where
     Apply::new(service.into_service(), f)
 }
 
-/// Service factory that prodices `apply_fn` service.
+/// Service factory that produces `apply_fn` service.
 pub fn apply_fn_factory<T, Req, Cfg, F, R, In, Out, Err, U>(
     service: U,
     f: F,

--- a/ntex-service/src/pipeline.rs
+++ b/ntex-service/src/pipeline.rs
@@ -8,7 +8,7 @@ use crate::then::{Then, ThenFactory};
 use crate::transform::{ApplyTransform, Transform};
 use crate::{IntoService, IntoServiceFactory, Service, ServiceFactory};
 
-/// Contruct new pipeline with one service in pipeline chain.
+/// Constructs new pipeline with one service in pipeline chain.
 pub fn pipeline<T, R, F>(service: F) -> Pipeline<T, R>
 where
     T: Service<R>,
@@ -20,7 +20,7 @@ where
     }
 }
 
-/// Contruct new pipeline factory with one service factory.
+/// Constructs new pipeline factory with one service factory.
 pub fn pipeline_factory<T, R, C, F>(factory: F) -> PipelineFactory<T, R, C>
 where
     T: ServiceFactory<R, C>,


### PR DESCRIPTION
The doc has never been updated since moving from `Request` associated type to a generic type parameter. 
