### PR TITLE
fixed openssl connect to "broker-cn.emqx.io:8883"/"54.87.92.106:8883" fail

### DIFF
--- a/ntex-connect/src/message.rs
+++ b/ntex-connect/src/message.rs
@@ -1,4 +1,7 @@
+use ntex_http::Uri;
 use std::collections::{vec_deque, VecDeque};
+use std::convert::TryFrom;
+use std::str::FromStr;
 use std::{fmt, iter::FromIterator, iter::FusedIterator, net::SocketAddr};
 
 use ntex_util::future::Either;
@@ -112,6 +115,16 @@ impl<T: Address> Connect<T> {
     /// Host name
     pub fn host(&self) -> &str {
         self.req.host()
+    }
+    /// only for openssl hostname
+    pub fn host_name(&self) -> String {
+        if let Ok(_) = SocketAddr::from_str(self.req.host()) {
+            return "".to_string();
+        } else {
+            Uri::try_from(self.req.host())
+                .map(|x| x.host().unwrap_or("").to_string())
+                .unwrap_or("".to_string())
+        }
     }
 
     /// Port of the request

--- a/ntex-connect/src/openssl.rs
+++ b/ntex-connect/src/openssl.rs
@@ -47,7 +47,7 @@ impl<T: Address + 'static> Connector<T> {
         Connect<T>: From<U>,
     {
         let message = Connect::from(message);
-        let host = message.host().to_string();
+        let host = message.host_name();
         let conn = self.connector.call(message);
         let openssl = self.openssl.clone();
 
@@ -57,7 +57,11 @@ impl<T: Address + 'static> Connector<T> {
 
             match openssl.configure() {
                 Err(e) => Err(io::Error::new(io::ErrorKind::Other, e).into()),
-                Ok(config) => {
+                Ok(mut config) => {
+                    if host == "" {
+                        config.set_verify_hostname(false);
+                        config.set_use_server_name_indication(false);
+                    }
                     let ssl = config
                         .into_ssl(&host)
                         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;


### PR DESCRIPTION
hello, when i connect to these addr like "broker-cn.emqx.io:8883" or "54.87.92.106:8883" by openssl. The original program will parse hostname to "broker-cn.emqx.io:8883" or "54.87.92.106:8883", but the dns name in cert is "broker-cn.emqx.io", so it will connect fail.

this pull request is to parse correctly hostname, if not, it will set openssl not to verify hostname.

this pull request just to fix this bug, I think you might have a more elegant solution!

