### PR TITLE
Moving from sha1 to sha256

### DIFF
--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -74,7 +74,7 @@ nanorand = { version = "0.7.0", default-features = false, features = ["std", "wy
 polling = "2.5.1"
 pin-project-lite = "0.2"
 regex = { version = "1.7.0", default-features = false, features = ["std"] }
-sha-1 = "0.10"
+sha2 = "0.10.6"
 serde = { version = "1.0", features=["derive"] }
 socket2 = "0.4"
 thiserror = "1.0"

--- a/ntex/src/ws/proto.rs
+++ b/ntex/src/ws/proto.rs
@@ -205,8 +205,8 @@ static WS_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 // TODO: hash is always same size, we dont need String
 pub fn hash_key(key: &[u8]) -> String {
-    use sha1::Digest;
-    let mut hasher = sha1::Sha1::new();
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
 
     hasher.update(key);
     hasher.update(WS_GUID.as_bytes());
@@ -280,7 +280,7 @@ mod test {
     #[test]
     fn test_hash_key() {
         let hash = hash_key(b"hello actix-web");
-        assert_eq!(&hash, "cR1dlyUUJKp0s/Bel25u5TgvC3E=");
+        assert_eq!(&hash, "Nhu7Loo1RnhBCRpUHHe8g1/pXQpaTRO/MaP3z4/eEfw=");
     }
 
     #[test]


### PR DESCRIPTION
My organization is flagging our use of ntex as insecure because it has sha1 has a dependency. Makes sense as the sha1 algorithm was demonstrated to be insecure a while ago. We would need an internal review to keep using ntex, which is a pain. This pull request gets ntex to use sha256 instead.  