### PR TITLE
Don't stop h1 dispatcher on upgrade handler with await (#149)

### DIFF
--- a/ntex/src/http/h1/dispatcher.rs
+++ b/ntex/src/http/h1/dispatcher.rs
@@ -219,6 +219,9 @@ where
                                     }
                                 }
                                 None
+                            } else if this.inner.flags.contains(Flags::UPGRADE_HND) {
+                                // continue on upgrade handler processing
+                                return Poll::Pending;
                             } else if this.inner.poll_io_closed(cx) {
                                 // check if io is closed
                                 *this.st = State::Stop;


### PR DESCRIPTION
Hi!
fixes  149  (research on  https://github.com/ntex-rs/examples/pull/13#issuecomment-1423991981 )
Don't sure on it.

When upgrade handler has some async context switching (await) dispatcher stops.


