### PR TITLE
Add `ClientResponse::headers_mut()` method

### DIFF
--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.6.3] - unreleased
+
+* http: Add `ClientResponse::headers_mut()` method
+
 ## [0.6.2] - 2023-01-24
 
 * Update ntex-io, ntex-tls deps

--- a/ntex/src/http/client/response.rs
+++ b/ntex/src/http/client/response.rs
@@ -57,7 +57,7 @@ impl HttpMessage for ClientResponse {
 }
 
 impl ClientResponse {
-    /// Create new Request instance
+    /// Create new client response instance
     pub(crate) fn new(head: ResponseHead, payload: Payload) -> Self {
         ClientResponse { head, payload }
     }
@@ -69,6 +69,11 @@ impl ClientResponse {
     #[inline]
     pub(crate) fn head(&self) -> &ResponseHead {
         &self.head
+    }
+
+    #[inline]
+    pub(crate) fn head_mut(&mut self) -> &mut ResponseHead {
+        &mut self.head
     }
 
     /// Read the Request Version.
@@ -90,9 +95,15 @@ impl ClientResponse {
     }
 
     #[inline]
-    /// Returns request's headers.
+    /// Returns response's headers.
     pub fn headers(&self) -> &HeaderMap {
         &self.head().headers
+    }
+
+    #[inline]
+    /// Returns mutable response's headers.
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        &mut self.head_mut().headers
     }
 
     /// Set a body and return previous body value


### PR DESCRIPTION
This would be useful when implementing reverse proxying, to modify response headers and taking them (without copying)
