### PR TITLE
Make `AppConfig::new()` constructor public

### DIFF
--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -3,6 +3,7 @@
 ## [0.6.3] - unreleased
 
 * http: Add `ClientResponse::headers_mut()` method
+* web: `AppConfig` can be created with custom parameters via `new()`
 
 ## [0.6.2] - 2023-01-24
 

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -19,7 +19,8 @@ struct AppConfigInner {
 }
 
 impl AppConfig {
-    pub(crate) fn new(secure: bool, addr: SocketAddr, host: String) -> Self {
+    /// Create an AppConfig instance.
+    pub fn new(secure: bool, addr: SocketAddr, host: String) -> Self {
         AppConfig(Rc::new(AppConfigInner { secure, host, addr }))
     }
 


### PR DESCRIPTION
Currently there is no way to construct `AppConfig` with non-default parameters or change it. However this would be useful when creating `web::App`  outside of `web::HttpServer` (eg. for manually created `HttpService`).

There are few methods exists such as `web::App::with_config()` that takes `AppConfig` and it's impossible to pass anything than `AppConfig::default()`.
