### PR TITLE
Synchronized buffer

### DIFF
--- a/ntex-service/CHANGES.md
+++ b/ntex-service/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [1.2.2] - 2023-06-24
+
+* Added `ServiceCall::advance_to_call`
+
 ## [1.2.1] - 2023-06-23
 
 * Make `PipelineCall` static

--- a/ntex-service/Cargo.toml
+++ b/ntex-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-service"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "ntex service"
 keywords = ["network", "framework", "async", "futures"]

--- a/ntex-service/src/lib.rs
+++ b/ntex-service/src/lib.rs
@@ -24,7 +24,7 @@ mod then;
 
 pub use self::apply::{apply_fn, apply_fn_factory};
 pub use self::chain::{chain, chain_factory};
-pub use self::ctx::{ServiceCall, ServiceCtx, ServiceCallToCall};
+pub use self::ctx::{ServiceCall, ServiceCallToCall, ServiceCtx};
 pub use self::fn_service::{fn_factory, fn_factory_with_config, fn_service};
 pub use self::fn_shutdown::fn_shutdown;
 pub use self::map_config::{map_config, unit_config};

--- a/ntex-service/src/lib.rs
+++ b/ntex-service/src/lib.rs
@@ -24,7 +24,7 @@ mod then;
 
 pub use self::apply::{apply_fn, apply_fn_factory};
 pub use self::chain::{chain, chain_factory};
-pub use self::ctx::{ServiceCall, ServiceCtx};
+pub use self::ctx::{ServiceCall, ServiceCtx, ServiceCallToCall};
 pub use self::fn_service::{fn_factory, fn_factory_with_config, fn_service};
 pub use self::fn_shutdown::fn_shutdown;
 pub use self::map_config::{map_config, unit_config};

--- a/ntex-util/CHANGES.md
+++ b/ntex-util/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.3.1] - 2023-06-24
+
+* Changed `BufferService` to maintain order 
+
+* Buffer error type changed to indicate cancellation
+
 ## [0.3.0] - 2023-06-22
 
 * Release v0.3.0

--- a/ntex-util/Cargo.toml
+++ b/ntex-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-util"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "Utilities for ntex framework"
 keywords = ["network", "framework", "async", "futures"]
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ntex-rt = "0.4.7"
-ntex-service = "1.2.0"
+ntex-service = "1.2.2"
 bitflags = "1.3"
 fxhash = "0.2.1"
 log = "0.4"

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -309,7 +309,7 @@ mod tests {
     use std::{rc::Rc, task::Context, task::Poll, time::Duration};
 
     use super::*;
-    use crate::future::{lazy, Ready};
+    use crate::{future::{lazy, Ready}, task::LocalWaker};
 
     #[derive(Clone)]
     struct TestService(Rc<Inner>);

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -132,7 +132,7 @@ where
     S: Service<R>,
 {
     type Response = S::Response;
-    type Error = BufferServiceRequestError<S::Error>;
+    type Error = BufferServiceError<S::Error>;
     type Future<'f> = BufferServiceResponse<'f, R, S> where Self: 'f, R: 'f;
 
     #[inline]
@@ -259,7 +259,7 @@ impl<'f, R, S> Future for BufferServiceResponse<'f, R, S>
 where
     S: Service<R>,
 {
-    type Output = Result<S::Response, BufferServiceRequestError<S::Error>>;
+    type Output = Result<S::Response, BufferServiceError<S::Error>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
@@ -273,7 +273,7 @@ where
                     }
                     Err(Canceled) => {
                         log::trace!("Buffered service request cancelled");
-                        Poll::Ready(Err(BufferServiceRequestError::RequestCancelled))
+                        Poll::Ready(Err(BufferServiceError::RequestCanceled))
                     }
                 }
             }
@@ -292,16 +292,29 @@ where
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BufferServiceRequestError<E> {
+pub enum BufferServiceError<E> {
     Service(E),
-    RequestCancelled,
+    RequestCanceled,
 }
 
-impl<E> From<E> for BufferServiceRequestError<E> {
+impl<E> From<E> for BufferServiceError<E> {
     fn from(err: E) -> Self {
-        BufferServiceRequestError::Service(err)
+        BufferServiceError::Service(err)
     }
 }
+
+impl<E: std::fmt::Display> std::fmt::Display for BufferServiceError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BufferServiceError::Service(e) => std::fmt::Display::fmt(e, f),
+            BufferServiceError::RequestCanceled => {
+                f.write_str("buffer service request canceled")
+            }
+        }
+    }
+}
+
+impl<E: std::fmt::Display + std::fmt::Debug> std::error::Error for BufferServiceError<E> {}
 
 #[cfg(test)]
 mod tests {
@@ -309,10 +322,8 @@ mod tests {
     use std::{rc::Rc, task::Context, task::Poll, time::Duration};
 
     use super::*;
-    use crate::{
-        future::{lazy, Ready},
-        task::LocalWaker,
-    };
+    use crate::future::{lazy, Ready};
+    use crate::task::LocalWaker;
 
     #[derive(Clone)]
     struct TestService(Rc<Inner>);

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -296,7 +296,7 @@ where
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BufferServiceRequestError<E> {
     Service(E),
     RequestCancelled,

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -272,7 +272,7 @@ where
                         self.poll(cx)
                     }
                     Err(Canceled) => {
-                        log::trace!("Buffered service request cancelled");
+                        log::trace!("Buffered service request canceled");
                         Poll::Ready(Err(BufferServiceError::RequestCanceled))
                     }
                 }

--- a/ntex-util/src/services/buffer.rs
+++ b/ntex-util/src/services/buffer.rs
@@ -309,7 +309,10 @@ mod tests {
     use std::{rc::Rc, task::Context, task::Poll, time::Duration};
 
     use super::*;
-    use crate::{future::{lazy, Ready}, task::LocalWaker};
+    use crate::{
+        future::{lazy, Ready},
+        task::LocalWaker,
+    };
 
     #[derive(Clone)]
     struct TestService(Rc<Inner>);


### PR DESCRIPTION
* added a new function to servicecall to allow only advancing to the service call and then returning the service response future
* buffer can maintain order/backpressure by implementing strict readiness and synchronous calling
* buffer can flush in order or cancel pending buffered futures on shutdown