### PR TITLE
fix: rust tls client TLS_SERVER_ROOTS

### DIFF
--- a/ntex/src/http/client/connector.rs
+++ b/ntex/src/http/client/connector.rs
@@ -86,15 +86,13 @@ impl Connector {
 
             let protos = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
             let mut cert_store = RootCertStore::empty();
-            cert_store.add_server_trust_anchors(
-                webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-                    OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        ta.subject,
-                        ta.spki,
-                        ta.name_constraints,
-                    )
-                }),
-            );
+            cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }));
             let mut config = ClientConfig::builder()
                 .with_safe_defaults()
                 .with_root_certificates(cert_store)


### PR DESCRIPTION
This fix a compilation error and also remove the deprecated usage of `add_server_trust_anchors` in favor of `add_trust_anchors`

![image](https://github.com/ntex-rs/ntex/assets/7750950/291a4619-68c8-4461-a744-21788561bf88)
