### PR TITLE
Add UnwindSafe trait on Receiver<T>

### DIFF
--- a/ntex-util/CHANGES.md
+++ b/ntex-util/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.3.4]
+
+* Add UnwindSafe trait on mpsc::Receiver<T> #239
+
 ## [0.3.3] - 2023-11-02
 
 * Add FusedStream trait on mpsc::Receiver<T> #235

--- a/ntex-util/src/channel/mpsc.rs
+++ b/ntex-util/src/channel/mpsc.rs
@@ -1,5 +1,7 @@
 //! A multi-producer, single-consumer, futures-aware, FIFO queue.
-use std::{collections::VecDeque, fmt, pin::Pin, task::Context, task::Poll};
+use std::{
+    collections::VecDeque, fmt, panic::UnwindSafe, pin::Pin, task::Context, task::Poll,
+};
 
 use futures_core::{FusedStream, Stream};
 use futures_sink::Sink;
@@ -211,6 +213,8 @@ impl<T> FusedStream for Receiver<T> {
         self.is_closed()
     }
 }
+
+impl<T> UnwindSafe for Receiver<T> {}
 
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
Add UnwindSafe trait on Receiver<T> to allow using catch_unwind on it