### PR TITLE
test(web): improve coverage for route and default errors

### DIFF
--- a/ntex/src/web/error.rs
+++ b/ntex/src/web/error.rs
@@ -679,6 +679,7 @@ mod tests {
     use std::io;
 
     use super::*;
+    use crate::http;
     use crate::http::client::error::{ConnectError, SendRequestError};
     use crate::web::test::TestRequest;
 
@@ -761,6 +762,10 @@ mod tests {
 
         #[allow(invalid_from_utf8)]
         let err = std::str::from_utf8(b"\xF0").unwrap_err();
+        let resp = WebResponseError::<DefaultError>::error_response(&err, &req);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let err = http::error::PayloadError::EncodingCorrupted;
         let resp = WebResponseError::<DefaultError>::error_response(&err, &req);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }

--- a/ntex/src/web/error.rs
+++ b/ntex/src/web/error.rs
@@ -758,6 +758,11 @@ mod tests {
         let err = PayloadError::Decoding;
         let resp = WebResponseError::<DefaultError>::error_response(&err, &req);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        #[allow(invalid_from_utf8)]
+        let err = std::str::from_utf8(b"\xF0").unwrap_err();
+        let resp = WebResponseError::<DefaultError>::error_response(&err, &req);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/ntex/src/web/error.rs
+++ b/ntex/src/web/error.rs
@@ -713,6 +713,12 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
 
         let resp = WebResponseError::<DefaultError>::error_response(
+            &TimeoutError::<UrlencodedError>::Service(UrlencodedError::Chunked),
+            &req,
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = WebResponseError::<DefaultError>::error_response(
             &SendRequestError::Connect(ConnectError::Timeout),
             &req,
         );

--- a/ntex/src/web/route.rs
+++ b/ntex/src/web/route.rs
@@ -372,5 +372,13 @@ mod tests {
 
         let body = read_body(resp).await;
         assert_eq!(body, Bytes::from_static(b"{\"name\":\"test\"}"));
+
+        let route: web::Route<DefaultError> =
+            web::get().to(|| async { HttpResponse::Ok() });
+        let repr = format!("{:?}", route);
+        assert!(repr.contains("Route"));
+        assert!(repr.contains("handler: Handler(\"ntex::web::route::tests::test_route::{{closure}}::{{closure}}\")"));
+        assert!(repr.contains("methods: [GET]"));
+        assert!(repr.contains("guards: AllGuard()"));
     }
 }

--- a/ntex/src/web/route.rs
+++ b/ntex/src/web/route.rs
@@ -375,11 +375,11 @@ mod tests {
         let body = read_body(resp).await;
         assert_eq!(body, Bytes::from_static(b"{\"name\":\"test\"}"));
 
-        let route: web::Route<DefaultError> =
-            web::get().to(|| async { HttpResponse::Ok() });
+        let route: web::Route<DefaultError> = web::get();
         let repr = format!("{:?}", route);
         assert!(repr.contains("Route"));
-        assert!(repr.contains("handler: Handler(\"ntex::web::route::tests::test_route::{{closure}}::{{closure}}\")"));
+        assert!(repr
+            .contains("handler: Handler(\"ntex::web::route::Route::new::{{closure}}\")"));
         assert!(repr.contains("methods: [GET]"));
         assert!(repr.contains("guards: AllGuard()"));
 
@@ -388,7 +388,8 @@ mod tests {
         let route_service = route.service();
         let repr = format!("{:?}", route_service);
         assert!(repr.contains("RouteService"));
-        assert!(repr.contains("handler: Handler(\"ntex::web::route::tests::test_route::{{closure}}::{{closure}}\")"));
+        assert!(repr
+            .contains("handler: Handler(\"ntex::web::route::Route::new::{{closure}}\")"));
         assert!(repr.contains("methods: [GET]"));
         assert!(repr.contains("guards: AllGuard()"));
     }

--- a/ntex/src/web/route.rs
+++ b/ntex/src/web/route.rs
@@ -278,6 +278,8 @@ array_routes!(12, a, b, c, d, e, f, g, h, i, j, k, l);
 
 #[cfg(test)]
 mod tests {
+    use ntex_service::ServiceFactory;
+
     use crate::http::{header, Method, StatusCode};
     use crate::time::{sleep, Millis};
     use crate::util::Bytes;
@@ -377,6 +379,15 @@ mod tests {
             web::get().to(|| async { HttpResponse::Ok() });
         let repr = format!("{:?}", route);
         assert!(repr.contains("Route"));
+        assert!(repr.contains("handler: Handler(\"ntex::web::route::tests::test_route::{{closure}}::{{closure}}\")"));
+        assert!(repr.contains("methods: [GET]"));
+        assert!(repr.contains("guards: AllGuard()"));
+
+        assert!(route.create(()).await.is_ok());
+
+        let route_service = route.service();
+        let repr = format!("{:?}", route_service);
+        assert!(repr.contains("RouteService"));
         assert!(repr.contains("handler: Handler(\"ntex::web::route::tests::test_route::{{closure}}::{{closure}}\")"));
         assert!(repr.contains("methods: [GET]"));
         assert!(repr.contains("guards: AllGuard()"));


### PR DESCRIPTION
Increased a bit the test coverage. around +0.06%.

![image](https://github.com/ntex-rs/ntex/assets/109926431/d540f7c6-1eca-41bc-88e7-cd8ad81edfc2)
