### PR TITLE
fix(github-actions): use rust toolchain arm64 version for macos 14

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - nightly
 
-    name: ${{ matrix.version }} - x86_64-apple-darwin
+    name: ${{ matrix.version }} - aarch64-apple-darwin
     runs-on: macOS-latest
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       - name: Install ${{ matrix.version }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ matrix.version }}-x86_64-apple-darwin
+          toolchain: ${{ matrix.version }}-aarch64-apple-darwin
 
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
@@ -29,13 +29,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
         run: cargo test --all --all-features --no-fail-fast -- --nocapture

--- a/ntex-bytes/tests/test_serde.rs
+++ b/ntex-bytes/tests/test_serde.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "serde")]
 #![deny(warnings, rust_2018_idioms)]
 
 use serde_test::{assert_tokens, Token};


### PR DESCRIPTION
The tests on MacOS runner were failing due to an error in the linking step:

> = note: ld: warning: ignoring file '/opt/homebrew/Cellar/openssl@3/3.3.0/lib/libssl.3.dylib': found architecture 'arm64', required architecture 'x86_64'

The tests seem to have started to fail recently which might be related to the update of macos 12 to 14 when using the tag `macos-latest` in the github runner:

One month ago:
![image](https://github.com/ntex-rs/ntex/assets/109926431/288ed207-72c0-44d0-b715-bf5c11bd0850)

Recently:
![image](https://github.com/ntex-rs/ntex/assets/109926431/3644d250-d2a3-4bc0-887d-9f072cb7672a)

It could be fixed by pinning the macos version to 12 or using the arm64 version toolchain.

In this pull request I updated the macos tests to use the arm64 version in case this results useful.
