### PR TITLE
test: improve coverage in client builder and time types

### DIFF
--- a/ntex-util/src/time/types.rs
+++ b/ntex-util/src/time/types.rs
@@ -227,7 +227,22 @@ mod tests {
         let m = Millis::from(Duration::from_secs(1));
         assert_eq!(m.0, 1000);
 
+        let m = Millis::from(Duration::from_secs(u64::MAX));
+        assert_eq!(m.0, 2_147_483_648);
+
+        let m = Millis::from_secs(1);
+        assert_eq!(m.0, 1000);
+
+        let m = Millis(0);
+        assert_eq!(m.map(|m| m + Millis(1)), None);
+
+        let m = Millis(1);
+        assert_eq!(m.map(|m| m + Millis(1)), Some(Millis(2)));
+
         let s = Seconds::new(10);
+        assert_eq!(s.0, 10);
+
+        let s = Seconds::checked_new(10);
         assert_eq!(s.0, 10);
 
         let s = Seconds::checked_new(u16::MAX as usize + 10);
@@ -247,5 +262,8 @@ mod tests {
 
         assert_eq!(Seconds(0).map(|_| 1usize), None);
         assert_eq!(Seconds(2).map(|_| 1usize), Some(1));
+
+        let d = Duration::from(Seconds(100));
+        assert_eq!(d.as_secs(), 100);
     }
 }

--- a/ntex/src/http/client/builder.rs
+++ b/ntex/src/http/client/builder.rs
@@ -176,6 +176,52 @@ mod tests {
     }
 
     #[crate::rt_test]
+    async fn response_payload_limit() {
+        let builder = ClientBuilder::default();
+        assert_eq!(builder.config.response_pl_limit, 262_144);
+
+        let builder = builder.response_payload_limit(10);
+        assert_eq!(builder.config.response_pl_limit, 10);
+    }
+
+    #[crate::rt_test]
+    async fn response_payload_timeout() {
+        let builder = ClientBuilder::default();
+        assert_eq!(builder.config.response_pl_timeout, Millis(10_000));
+
+        let builder = builder.response_payload_timeout(Millis(10));
+        assert_eq!(builder.config.response_pl_timeout, Millis(10));
+    }
+
+    #[crate::rt_test]
+    async fn valid_header_name() {
+        let builder = ClientBuilder::new().header("Content-Length", 1);
+        assert!(builder.config.headers.contains_key("Content-Length"));
+    }
+
+    #[crate::rt_test]
+    async fn invalid_header_name() {
+        let builder = ClientBuilder::new().header("no valid header name", 1);
+        assert!(!builder.config.headers.contains_key("no valid header name"));
+    }
+
+    #[crate::rt_test]
+    async fn valid_header_value() {
+        let valid_header_value = HeaderValue::from(1234);
+        let builder = ClientBuilder::new().header("Content-Length", &valid_header_value);
+        assert_eq!(
+            builder.config.headers.get("Content-Length"),
+            Some(&valid_header_value)
+        );
+    }
+
+    #[crate::rt_test]
+    async fn invalid_header_value() {
+        let builder = ClientBuilder::new().header("Content-Length", "\n");
+        assert!(!builder.config.headers.contains_key("Content-Length"));
+    }
+
+    #[crate::rt_test]
     async fn client_basic_auth() {
         let client = ClientBuilder::new().basic_auth("username", Some("password"));
         assert_eq!(


### PR DESCRIPTION
Increased a bit the test coverage. around +0.12%.

![image](https://github.com/ntex-rs/ntex/assets/109926431/f70b42b3-1312-4480-b914-1a801105502a)
