### PR TITLE
Publicize Connect trait access

### DIFF
--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "Framework for composable network services"
 readme = "README.md"

--- a/ntex/src/http/client/builder.rs
+++ b/ntex/src/http/client/builder.rs
@@ -55,6 +55,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Use custom connection.  Mainly used for mocking connections.
+    /// # Note
+    /// This overrides anything set with [`Self::connector`].
+    pub fn connection(mut self, connection: impl super::connect::Connect + 'static) -> Self
+    {
+        self.config.connector = Box::new(connection);
+        self
+    }
+
     /// Set request timeout.
     ///
     /// Request timeout is the total time before a response must be received.

--- a/ntex/src/http/client/builder.rs
+++ b/ntex/src/http/client/builder.rs
@@ -58,8 +58,10 @@ impl ClientBuilder {
     /// Use custom connection.  Mainly used for mocking connections.
     /// # Note
     /// This overrides anything set with [`Self::connector`].
-    pub fn connection(mut self, connection: impl super::connect::Connect + 'static) -> Self
-    {
+    pub fn connection(
+        mut self,
+        connection: impl super::connect::Connect + 'static,
+    ) -> Self {
         self.config.connector = Box::new(connection);
         self
     }

--- a/ntex/src/http/client/builder.rs
+++ b/ntex/src/http/client/builder.rs
@@ -57,7 +57,8 @@ impl ClientBuilder {
 
     /// Use custom connection.  Mainly used for mocking connections.
     /// # Note
-    /// This overrides anything set with [`Self::connector`].
+    /// This overrides anything set with [`Self::connector`]. 
+    #[doc(hidden)]
     pub fn connection(
         mut self,
         connection: impl super::connect::Connect + 'static,

--- a/ntex/src/http/client/connect.rs
+++ b/ntex/src/http/client/connect.rs
@@ -20,6 +20,7 @@ where
     }
 }
 
+#[doc(hidden)]
 pub trait Connect: fmt::Debug {
     fn send_request(
         &self,

--- a/ntex/src/http/client/connect.rs
+++ b/ntex/src/http/client/connect.rs
@@ -20,7 +20,7 @@ where
     }
 }
 
-pub(super) trait Connect: fmt::Debug {
+pub trait Connect: fmt::Debug {
     fn send_request(
         &self,
         head: RequestHeadType,

--- a/ntex/src/http/client/mod.rs
+++ b/ntex/src/http/client/mod.rs
@@ -19,7 +19,7 @@
 use std::rc::Rc;
 
 mod builder;
-mod connect;
+pub mod connect;
 mod connection;
 mod connector;
 pub mod error;
@@ -74,12 +74,12 @@ pub struct Connect {
 pub struct Client(Rc<ClientConfig>);
 
 #[derive(Debug)]
-pub(crate) struct ClientConfig {
+pub struct ClientConfig {
     pub(self) connector: Box<dyn HttpConnect>,
-    pub(self) headers: HeaderMap,
-    pub(self) timeout: Millis,
-    pub(self) response_pl_limit: usize,
-    pub(self) response_pl_timeout: Millis,
+    pub headers: HeaderMap,
+    pub timeout: Millis,
+    pub response_pl_limit: usize,
+    pub response_pl_timeout: Millis,
 }
 
 impl Default for ClientConfig {

--- a/ntex/src/http/client/mod.rs
+++ b/ntex/src/http/client/mod.rs
@@ -74,6 +74,7 @@ pub struct Connect {
 pub struct Client(Rc<ClientConfig>);
 
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct ClientConfig {
     pub(self) connector: Box<dyn HttpConnect>,
     pub headers: HeaderMap,

--- a/ntex/src/http/client/response.rs
+++ b/ntex/src/http/client/response.rs
@@ -59,7 +59,7 @@ impl HttpMessage for ClientResponse {
 
 impl ClientResponse {
     /// Create new client response instance
-    pub(crate) fn new(
+    pub fn new(
         head: ResponseHead,
         payload: Payload,
         config: Rc<ClientConfig>,

--- a/ntex/src/http/client/response.rs
+++ b/ntex/src/http/client/response.rs
@@ -59,6 +59,7 @@ impl HttpMessage for ClientResponse {
 
 impl ClientResponse {
     /// Create new client response instance
+    #[doc(hidden)]
     pub fn new(head: ResponseHead, payload: Payload, config: Rc<ClientConfig>) -> Self {
         ClientResponse {
             head,

--- a/ntex/src/http/client/response.rs
+++ b/ntex/src/http/client/response.rs
@@ -59,11 +59,7 @@ impl HttpMessage for ClientResponse {
 
 impl ClientResponse {
     /// Create new client response instance
-    pub fn new(
-        head: ResponseHead,
-        payload: Payload,
-        config: Rc<ClientConfig>,
-    ) -> Self {
+    pub fn new(head: ResponseHead, payload: Payload, config: Rc<ClientConfig>) -> Self {
         ClientResponse {
             head,
             payload,


### PR DESCRIPTION
Somewhere after ntex 0.4, the Connect was renamed and made internal, however I'm not seeing an issue with making it public for some testing scenarios.