### PR TITLE
Add workflow job which adds basic checks for build failures

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,17 @@ name: Checks
 on: [push, pull_request]
 
 jobs:
+  check:
+    name: Check for build failures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run:
+          cargo check --all --no-default-features --features="ntex/compio,ntex/cookie,ntex/url,ntex/compress,ntex/openssl,ntex/rustls,ntex/ws,ntex/brotli"
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
I tried to compile ntex with the `rustls` flag enabled, and got a lot of build-time errors. This addition will help prevent subsequent build failures. I suggest merging this after `rustls`-enabled builds are fixed.