### PR TITLE
Feature/runtime macro panic

### DIFF
--- a/ntex-macros/Cargo.toml
+++ b/ntex-macros/Cargo.toml
@@ -1,11 +1,27 @@
 [package]
 name = "ntex-macros"
-version = "0.1.3"
+version = "0.1.4"
 description = "ntex proc macros"
 readme = "README.md"
 authors = ["ntex contributors <team@ntex.rs>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+
+[features]
+
+default = []
+
+# glommio support
+glommio = []
+
+# tokio support
+tokio = []
+
+# compio support
+compio = []
+
+# async-std support
+async-std = []
 
 [lib]
 proc-macro = true

--- a/ntex-macros/src/lib.rs
+++ b/ntex-macros/src/lib.rs
@@ -197,6 +197,12 @@ pub fn web_patch(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
+#[cfg(any(
+    feature = "tokio",
+    feature = "async-std",
+    feature = "compio",
+    feature = "glommio"
+))]
 pub fn rt_main(_: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = syn::parse_macro_input!(item as syn::ItemFn);
     let attrs = &input.attrs;
@@ -223,6 +229,17 @@ pub fn rt_main(_: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
+#[proc_macro_attribute]
+#[cfg(not(any(
+    feature = "tokio",
+    feature = "async-std",
+    feature = "compio",
+    feature = "glommio"
+)))]
+pub fn rt_main(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("Runtime must be selected '--feature=ntex/$runtime', available options are 'compio', 'tokio', 'async-std', 'glommio'");
+}
+
 /// Marks async test function to be executed by ntex runtime.
 ///
 /// ## Usage
@@ -234,6 +251,12 @@ pub fn rt_main(_: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
+#[cfg(any(
+    feature = "tokio",
+    feature = "async-std",
+    feature = "compio",
+    feature = "glommio"
+))]
 pub fn rt_test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 
@@ -278,6 +301,17 @@ pub fn rt_test(_: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     result.into()
+}
+
+#[proc_macro_attribute]
+#[cfg(not(any(
+    feature = "tokio",
+    feature = "async-std",
+    feature = "compio",
+    feature = "glommio"
+)))]
+pub fn rt_test(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("Runtime must be selected '--feature=ntex/$runtime', available options are 'compio', 'tokio', 'async-std', 'glommio'");
 }
 
 /// Marks async test function to be executed by ntex runtime.

--- a/ntex-rt/build.rs
+++ b/ntex-rt/build.rs
@@ -13,7 +13,7 @@ fn main() {
         };
     }
 
-    if features.len() > 1 {
+    if !clippy && features.len() > 1 {
         panic!(
             "Only one runtime feature could be selected, current selection {:?}",
             features

--- a/ntex-rt/build.rs
+++ b/ntex-rt/build.rs
@@ -13,7 +13,7 @@ fn main() {
         };
     }
 
-    if !clippy && features.len() > 1 {
+    if features.len() > 1 {
         panic!(
             "Only one runtime feature could be selected, current selection {:?}",
             features

--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex"
-version = "2.10.0"
+version = "2.11.0"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "Framework for composable network services"
 readme = "README.md"
@@ -43,16 +43,16 @@ cookie = ["coo-kie", "coo-kie/percent-encode"]
 url = ["url-pkg"]
 
 # tokio runtime
-tokio = ["ntex-net/tokio"]
+tokio = ["ntex-net/tokio", "ntex-macros/tokio"]
 
 # glommio runtime
-glommio = ["ntex-net/glommio"]
+glommio = ["ntex-net/glommio", "ntex-macros/glommio"]
 
 # async-std runtime
-async-std = ["ntex-net/async-std"]
+async-std = ["ntex-net/async-std", "ntex-macros/async-std"]
 
 # compio runtime
-compio = ["ntex-net/compio"]
+compio = ["ntex-net/compio", "ntex-macros/compio"]
 
 # websocket support
 ws = ["dep:sha-1"]


### PR DESCRIPTION
Removes the build script check for selecting a runtime.  This check prevents building libraries that rely on ntex without using any runtime features.

Instead, moves the runtime checks to the two main places I think would matter for build time checking: test and main macros (with the runtime failures still left in place).