### PR TITLE
Publicize web::app_service::AppService

### DIFF
--- a/ntex/src/web/mod.rs
+++ b/ntex/src/web/mod.rs
@@ -128,6 +128,7 @@ pub mod dev {
     //! The purpose of this module is to alleviate imports of many common
     //! traits by adding a glob import to the top of ntex::web heavy modules:
 
+    pub use crate::web::app_service::AppService;
     pub use crate::web::config::AppConfig;
     pub use crate::web::info::ConnectionInfo;
     pub use crate::web::rmap::ResourceMap;


### PR DESCRIPTION
The primary motivation it to let me name a type that can be passed into `ntex::web::server` such that a `web::App` could be defined once, and run in different contexts;

```rust
// WARNING: pseudo-code
async fn run_server_with_tls<M, F, Err>(
    app_factory: impl Fn() -> ntex::web::App<M, F, Err> + Send + Clone + 'static,
) where
    M: ntex::Middleware<ntex::web::AppService<F::Service, Err>> + 'static,
    M::Service: ntex::Service<
        ntex::web::WebRequest<Err>,
        Response = ntex::web::WebResponse,
        Error = Err::Container,
    >,
    F: ntex::ServiceFactory<
        ntex::web::WebRequest<Err>,
        Response = ntex::web::WebRequest<Err>,
        Error = Err::Container,
        InitError = (),
    >,
    F: 'static,
    Err: ntex::web::ErrorRenderer,
{ /* ... */ }

async fn run_server_with_plaintext<M, F, Err>(
    app_factory: impl Fn() -> ntex::web::App<M, F, Err> + Send + Clone + 'static
) where
    M: ntex::Middleware<ntex::web::AppService<F::Service, Err>> + 'static,
    // ...
{ /* ... */ }

fn main() {
    let state = ...;
    let app_factory = move || {
        web::App::new()
            .state(state)
            .route(...)
    };
    if TLS {
        run_server_with_tls(app_factory);
    } else {
        run_server_with_plaintext(app_factory);
    }
}
```

More precisely, this type needs to be publicized to allow consumers to bound `App`s enough to access the `impl<...> IntoServiceFactory<...> for App<...>` trait impls defined web/app.rs.