### PR TITLE
add public ServiceConfig::register constructor to support external configuration (#250)

### DIFF
--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -133,9 +133,9 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
     /// # Examples
     ///
     /// ```rust
-    /// use ntex::web::ServiceConfig;
+    /// use ntex::web::{ServiceConfig, DefaultError};
     ///
-    /// let config = ServiceConfig::register();
+    /// let config: ServiceConfig<DefaultError>  = ServiceConfig::register();
     /// ```
     pub fn register() -> Self {
         Self {

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -68,7 +68,7 @@ pub struct ServiceConfig<Err = DefaultError> {
 }
 
 impl<Err: ErrorRenderer> ServiceConfig<Err> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             services: Vec::new(),
             state: Extensions::new(),
@@ -123,26 +123,6 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
         *rdef.name_mut() = name.as_ref().to_string();
         self.external.push(rdef);
         self
-    }
-
-    /// Creates a new instance of [`ServiceConfig`] for use in custom application configurations.
-    ///
-    /// This is an alternative constructor to [`ServiceConfig::new()`], intended for
-    /// external crates and libraries that require access to [`ServiceConfig`] outside the crate scope.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ntex::web::{ServiceConfig, DefaultError};
-    ///
-    /// let config: ServiceConfig<DefaultError>  = ServiceConfig::register();
-    /// ```
-    pub fn register() -> Self {
-        Self {
-            services: Vec::new(),
-            state: Extensions::new(),
-            external: Vec::new(),
-        }
     }
 }
 
@@ -227,8 +207,8 @@ mod tests {
     }
 
     #[test]
-    fn test_service_config_register() {
-        let cfg: ServiceConfig<DefaultError> = ServiceConfig::register();
+    fn test_new_service_config() {
+        let cfg: ServiceConfig<DefaultError> = ServiceConfig::new();
         assert!(cfg.services.is_empty());
         assert!(cfg.external.is_empty());
     }

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -124,6 +124,26 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
         self.external.push(rdef);
         self
     }
+
+    /// Creates a new instance of [`ServiceConfig`] for use in custom application configurations.
+    ///
+    /// This is an alternative constructor to [`ServiceConfig::new()`], intended for
+    /// external crates and libraries that require access to [`ServiceConfig`] outside the crate scope.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ntex::web::ServiceConfig;
+    ///
+    /// let config = ServiceConfig::register();
+    /// ```
+    pub fn register() -> Self {
+        Self {
+            services: Vec::new(),
+            state: Extensions::new(),
+            external: Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -152,7 +152,7 @@ mod tests {
     use crate::http::{Method, StatusCode};
     use crate::util::Bytes;
     use crate::web::test::{call_service, init_service, read_body, TestRequest};
-    use crate::web::{self, App, HttpRequest, HttpResponse};
+    use crate::web::{self, App, DefaultError, HttpRequest, HttpResponse};
 
     #[crate::rt_test]
     async fn test_configure_state() {
@@ -224,5 +224,12 @@ mod tests {
             .to_request();
         let resp = call_service(&srv, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_service_config_register() {
+        let cfg: ServiceConfig<DefaultError> = ServiceConfig::register();
+        assert!(cfg.services.is_empty());
+        assert!(cfg.external.is_empty());
     }
 }


### PR DESCRIPTION
The current `ServiceConfig::new()` constructor is not accessible externally `pub(crate)`, which limits extensibility for third-party libraries that want to introspect or modify service config before registering it into an app.

This change unlocks that ability, enabling cleaner integration with tools like API docs generators or plugin-style configuration injection.

Therefore, This PR introduces a new public associated function `ServiceConfig::register` which acts as an alternative constructor.

The purpose of this function is to allow creating an empty `ServiceConfig` from outside the crate. This is especially useful for cases like `OpenAPI` doc generation (e.g. `utoipa`) where we need to construct and inspect the service configuration independently from `App::configure`.

**Related issue:** Closes #250