### PR TITLE
Expose WebStack for external wrapper support in downstream crates

### DIFF
--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -133,9 +133,9 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
     /// # Examples
     ///
     /// ```rust
-    /// use ntex::web::ServiceConfig;
+    /// use ntex::web::{ServiceConfig, DefaultError};
     ///
-    /// let config = ServiceConfig::register();
+    /// let config: ServiceConfig<DefaultError>  = ServiceConfig::register();
     /// ```
     pub fn register() -> Self {
         Self {

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::http::{Method, StatusCode};
     use crate::util::Bytes;
     use crate::web::test::{call_service, init_service, read_body, TestRequest};
-    use crate::web::{self, App, DefaultError, HttpRequest, HttpResponse};
+    use crate::web::{self, App, HttpRequest, HttpResponse};
 
     #[crate::rt_test]
     async fn test_configure_state() {

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -68,7 +68,7 @@ pub struct ServiceConfig<Err = DefaultError> {
 }
 
 impl<Err: ErrorRenderer> ServiceConfig<Err> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             services: Vec::new(),
             state: Extensions::new(),
@@ -123,26 +123,6 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
         *rdef.name_mut() = name.as_ref().to_string();
         self.external.push(rdef);
         self
-    }
-
-    /// Creates a new instance of [`ServiceConfig`] for use in custom application configurations.
-    ///
-    /// This is an alternative constructor to [`ServiceConfig::new()`], intended for
-    /// external crates and libraries that require access to [`ServiceConfig`] outside the crate scope.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ntex::web::{ServiceConfig, DefaultError};
-    ///
-    /// let config: ServiceConfig<DefaultError>  = ServiceConfig::register();
-    /// ```
-    pub fn register() -> Self {
-        Self {
-            services: Vec::new(),
-            state: Extensions::new(),
-            external: Vec::new(),
-        }
     }
 }
 
@@ -227,8 +207,8 @@ mod tests {
     }
 
     #[test]
-    fn test_service_config_register() {
-        let cfg: ServiceConfig<DefaultError> = ServiceConfig::register();
+    fn test_new_service_config() {
+        let cfg: ServiceConfig<DefaultError> = ServiceConfig::new();
         assert!(cfg.services.is_empty());
         assert!(cfg.external.is_empty());
     }

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -124,6 +124,26 @@ impl<Err: ErrorRenderer> ServiceConfig<Err> {
         self.external.push(rdef);
         self
     }
+
+    /// Creates a new instance of [`ServiceConfig`] for use in custom application configurations.
+    ///
+    /// This is an alternative constructor to [`ServiceConfig::new()`], intended for
+    /// external crates and libraries that require access to [`ServiceConfig`] outside the crate scope.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ntex::web::ServiceConfig;
+    ///
+    /// let config = ServiceConfig::register();
+    /// ```
+    pub fn register() -> Self {
+        Self {
+            services: Vec::new(),
+            state: Extensions::new(),
+            external: Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -152,7 +152,7 @@ mod tests {
     use crate::http::{Method, StatusCode};
     use crate::util::Bytes;
     use crate::web::test::{call_service, init_service, read_body, TestRequest};
-    use crate::web::{self, App, HttpRequest, HttpResponse};
+    use crate::web::{self, App, DefaultError, HttpRequest, HttpResponse};
 
     #[crate::rt_test]
     async fn test_configure_state() {
@@ -224,5 +224,12 @@ mod tests {
             .to_request();
         let resp = call_service(&srv, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_service_config_register() {
+        let cfg: ServiceConfig<DefaultError> = ServiceConfig::register();
+        assert!(cfg.services.is_empty());
+        assert!(cfg.external.is_empty());
     }
 }

--- a/ntex/src/web/config.rs
+++ b/ntex/src/web/config.rs
@@ -68,7 +68,7 @@ pub struct ServiceConfig<Err = DefaultError> {
 }
 
 impl<Err: ErrorRenderer> ServiceConfig<Err> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             services: Vec::new(),
             state: Extensions::new(),
@@ -204,12 +204,5 @@ mod tests {
             .to_request();
         let resp = call_service(&srv, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[test]
-    fn test_new_service_config() {
-        let cfg: ServiceConfig<DefaultError> = ServiceConfig::new();
-        assert!(cfg.services.is_empty());
-        assert!(cfg.external.is_empty());
     }
 }

--- a/ntex/src/web/mod.rs
+++ b/ntex/src/web/mod.rs
@@ -82,7 +82,7 @@ mod route;
 mod scope;
 mod server;
 mod service;
-mod stack;
+pub mod stack;
 pub mod test;
 pub mod types;
 mod util;


### PR DESCRIPTION
## About this PR
While working on [utoipa-ntex](https://github.com/Rayato159/utoipa/tree/add-utopia-ntex) integration, I ran into a blocker when trying to implement a passthrough for `Scope::wrap(...)`.

Currently, this function returns a `WebStack<M, U, Err>`, but `WebStack` itself is not public. This makes it impossible to use in wrapper logic (such as passthroughs in third-party crates) because the return type cannot be constructed or referenced.

## Changes
- Make WebStack public `pub` so external libraries can properly wrap or extend Scope functionality.
- Revert `ServiceConfig::new()` from pub back to `pub(crate)`, I previously made this public, but upon further review, it's unnecessary and not idiomatic for the public API. Apologies for the earlier oversight 🙇‍♂️. (Previous PR in #539)

## Example of problem
This change enables use cases like this example from `utoipa-ntex`, where we're implementing passthrough support for `wrap(...)` on a custom `Scope` type:

```rust
impl<Err, M, T> Scope<Err, M, T>
where
    T: ServiceFactory<
        WebRequest<Err>,
        Response = WebRequest<Err>,
        Error = Err::Container,
        InitError = (),
    >,
    Err: ErrorRenderer,
{
    /// Passthrough implementation for [`ntex::web::Scope::wrap`]
    pub fn wrap<U>(self, mw: U) -> Scope<Err, WebStack<M, U, Err>, T> {
        // ERROR: WebStack is private, cannot use in return type without this PR
        Scope(self.0.wrap(mw), self.1, self.2)
    }
}
```
---

Let me know if anything should be adjusted!

Thanks for your time and effort on maintaining the `ntex`

Best regards,
Rayato159