### PR TITLE
Fix docs rs

### DIFF
--- a/ntex/Cargo.toml
+++ b/ntex/Cargo.toml
@@ -23,7 +23,6 @@ features = ["tokio", "openssl", "rustls", "compress", "cookie", "ws", "ntex-tls/
 rustc-args = ["--cfg", "docsrs_dep"]
 rustdoc-args = [
     "--cfg", "docsrs_dep",
-    "--html-after-content", "docs-rs/trait-tags.html",
 ]
 
 [lints.rust]


### PR DESCRIPTION
Added too many args to cargo.toml and it's breaking docs build, removing them should fix it.