### PR TITLE
Fix the rustls need for wait

### DIFF
--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -133,15 +133,16 @@ impl<T: Address> Service<Connect<T>> for SslConnector<T> {
 mod tests {
     use super::*;
 
+    use ntex::codec::BytesCodec;
     use ntex_bytes::Bytes;
     use tls_openssl::ssl::SslMethod;
-    use ntex::codec::BytesCodec;
 
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
             ntex::service::fn_service(|io: Io| async move {
-                io.send(Bytes::from_static(b"Hello"), &BytesCodec).await
+                io.send(Bytes::from_static(b"Hello"), &BytesCodec)
+                    .await
                     .expect("Failed to send data");
                 Ok::<_, ()>(())
             })

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -138,7 +138,7 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_: Io| async move { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async move { Ok::<_, ()>(()) })
         });
 
         let ssl = BaseSslConnector::builder(SslMethod::tls()).unwrap();

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -133,8 +133,6 @@ impl<T: Address> Service<Connect<T>> for SslConnector<T> {
 mod tests {
     use super::*;
 
-    use ntex::codec::BytesCodec;
-    use ntex_bytes::Bytes;
     use tls_openssl::ssl::SslMethod;
 
     #[ntex::test]

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -138,7 +138,7 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async move { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async { Ok::<_, ()>(()) })
         });
 
         let ssl = BaseSslConnector::builder(SslMethod::tls()).unwrap();

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -131,16 +131,19 @@ impl<T: Address> Service<Connect<T>> for SslConnector<T> {
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
-    use tls_openssl::ssl::SslMethod;
-
     use super::*;
+
+    use ntex_bytes::Bytes;
+    use tls_openssl::ssl::SslMethod;
+    use ntex::codec::BytesCodec;
 
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io| async {
-                io.write("Testing");
-                Ok::<_, ()>(()) 
+            ntex::service::fn_service(|io: Io| async move {
+                io.send(Bytes::from_static(b"Hello"), &BytesCodec).await
+                    .expect("Failed to send data");
+                Ok::<_, ()>(())
             })
         });
 

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -140,12 +140,7 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io: Io| async move {
-                io.send(Bytes::from_static(b"Hello"), &BytesCodec)
-                    .await
-                    .expect("Failed to send data");
-                Ok::<_, ()>(())
-            })
+            ntex::service::fn_service(|io: Io| async move { Ok::<_, ()>(()) })
         });
 
         let ssl = BaseSslConnector::builder(SslMethod::tls()).unwrap();

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -138,7 +138,10 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async {
+                io.write("Testing");
+                Ok::<_, ()>(()) 
+            })
         });
 
         let ssl = BaseSslConnector::builder(SslMethod::tls()).unwrap();

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -156,6 +156,8 @@ mod tests {
             .clone();
 
         let srv = factory.pipeline(&()).await.unwrap();
+        // always ready
+        assert!(lazy(|cx| srv.poll_ready(cx)).await.is_ready());
         let result = srv
             .call(Connect::new("").set_addr(Some(server.addr())))
             .await;

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -157,7 +157,7 @@ mod tests {
 
         let srv = factory.pipeline(&()).await.unwrap();
         // always ready
-        assert!(lazy(|cx| srv.poll_ready(cx)).await.is_ready());
+        assert!(srv.ready().await.is_ok());
         let result = srv
             .call(Connect::new("").set_addr(Some(server.addr())))
             .await;

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -138,7 +138,7 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async {
+            ntex::service::fn_service(|io| async {
                 io.write("Testing");
                 Ok::<_, ()>(()) 
             })

--- a/ntex-tls/src/openssl/connect.rs
+++ b/ntex-tls/src/openssl/connect.rs
@@ -138,7 +138,7 @@ mod tests {
     #[ntex::test]
     async fn test_openssl_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io: Io| async move { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_: Io| async move { Ok::<_, ()>(()) })
         });
 
         let ssl = BaseSslConnector::builder(SslMethod::tls()).unwrap();

--- a/ntex-tls/src/rustls/client.rs
+++ b/ntex-tls/src/rustls/client.rs
@@ -172,6 +172,8 @@ impl TlsClientFilter {
                             let _ = session.write_tls(&mut wrp);
                             io::Error::new(io::ErrorKind::InvalidData, err)
                         })?;
+                    } else {
+                        result = Err(io::Error::new(io::ErrorKind::WouldBlock, ""));
                     }
                 }
 

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -148,7 +148,10 @@ mod tests {
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async {
+                io.write("Testing");
+                Ok::<_, ()>(()) 
+            })
         });
 
         let cert_store =

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -148,7 +148,7 @@ mod tests {
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async {
+            ntex::service::fn_service(|io| async {
                 io.write("Testing");
                 Ok::<_, ()>(()) 
             })

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -148,7 +148,7 @@ mod tests {
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|_| async move { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async { Ok::<_, ()>(()) })
         });
 
         let cert_store =

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -142,16 +142,17 @@ impl<T: Address> Service<Connect<T>> for TlsConnector<T> {
 mod tests {
     use super::*;
 
+    use ntex::codec::BytesCodec;
     use ntex_bytes::Bytes;
     use ntex_util::future::lazy;
     use tls_rust::RootCertStore;
-    use ntex::codec::BytesCodec;
 
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
             ntex::service::fn_service(|io: Io| async move {
-                io.send(Bytes::from_static(b"Invalid data"), &BytesCodec).await
+                io.send(Bytes::from_static(b"Invalid data"), &BytesCodec)
+                    .await
                     .expect("Failed to send data");
                 Ok::<_, ()>(())
             })

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -150,12 +150,7 @@ mod tests {
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io: Io| async move {
-                io.send(Bytes::from_static(b"Invalid data"), &BytesCodec)
-                    .await
-                    .expect("Failed to send data");
-                Ok::<_, ()>(())
-            })
+            ntex::service::fn_service(|io: Io| async move { Ok::<_, ()>(()) })
         });
 
         let cert_store =

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -142,15 +142,18 @@ impl<T: Address> Service<Connect<T>> for TlsConnector<T> {
 mod tests {
     use super::*;
 
+    use ntex_bytes::Bytes;
     use ntex_util::future::lazy;
     use tls_rust::RootCertStore;
+    use ntex::codec::BytesCodec;
 
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io| async {
-                io.write("Testing");
-                Ok::<_, ()>(()) 
+            ntex::service::fn_service(|io: Io| async move {
+                io.send(Bytes::from_static(b"Hello"), &BytesCodec).await
+                    .expect("Failed to send data");
+                Ok::<_, ()>(())
             })
         });
 

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -148,7 +148,7 @@ mod tests {
     #[ntex::test]
     async fn test_rustls_connect() {
         let server = ntex::server::test_server(|| {
-            ntex::service::fn_service(|io: Io| async move { Ok::<_, ()>(()) })
+            ntex::service::fn_service(|_| async move { Ok::<_, ()>(()) })
         });
 
         let cert_store =

--- a/ntex-tls/src/rustls/connect.rs
+++ b/ntex-tls/src/rustls/connect.rs
@@ -142,8 +142,6 @@ impl<T: Address> Service<Connect<T>> for TlsConnector<T> {
 mod tests {
     use super::*;
 
-    use ntex::codec::BytesCodec;
-    use ntex_bytes::Bytes;
     use ntex_util::future::lazy;
     use tls_rust::RootCertStore;
 

--- a/ntex-tls/src/rustls/server.rs
+++ b/ntex-tls/src/rustls/server.rs
@@ -182,6 +182,8 @@ impl TlsServerFilter {
                                 let _ = session.write_tls(&mut wrp);
                                 io::Error::new(io::ErrorKind::InvalidData, err)
                             })?;
+                        } else {
+                            result = Err(io::Error::new(io::ErrorKind::WouldBlock, ""));
                         }
                     }
                     Ok::<_, io::Error>((result, session.is_handshaking()))


### PR DESCRIPTION
Since the connection returned "Ok()" even when the handshake was not complete in case session.wants_read() returned true, but has_data is false, the connection did not expect the ServerHello or even complete the handshake, causing the error of always returning that the protocol is HTTP1 because the anpl_protocols function returned None