### PR TITLE
fix: avoid ci issue of not enough disk space

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -9,6 +9,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+      - uses: jlumbroso/free-disk-space@main
       - uses: taiki-e/install-action@nextest
 
       - name: Install Rust


### PR DESCRIPTION
Added github action that frees up a bit of disk space to avoid the below error in the coverage workflow:
```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251230-115407-utc.log'
```