### PR TITLE
docs: update deprecation attribute for `wrap()`

### DIFF
--- a/ntex/src/web/app.rs
+++ b/ntex/src/web/app.rs
@@ -444,7 +444,7 @@ where
         }
     }
 
-    #[deprecated]
+    #[deprecated(since = "3.2.0", note = "use `middleware()` instead")]
     #[doc(hidden)]
     pub fn wrap<U>(self, mw: U) -> App<WebStack<M, U, Err>, T, Err> {
         self.middleware(mw)

--- a/ntex/src/web/resource.rs
+++ b/ntex/src/web/resource.rs
@@ -300,7 +300,7 @@ where
         }
     }
 
-    #[deprecated]
+    #[deprecated(since = "3.2.0", note = "use `middleware()` instead")]
     #[doc(hidden)]
     pub fn wrap<U>(self, mw: U) -> Resource<Err, WebStack<M, U, Err>, T> {
         self.middleware(mw)
@@ -552,7 +552,7 @@ mod tests {
             App::new().service(
                 web::resource("/test")
                     .name("test")
-                    .wrap(
+                    .middleware(
                         DefaultHeaders::new()
                             .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
                     )

--- a/ntex/src/web/scope.rs
+++ b/ntex/src/web/scope.rs
@@ -376,7 +376,7 @@ where
     }
 
     #[doc(hidden)]
-    #[deprecated]
+    #[deprecated(since = "3.2.0", note = "use `middleware()` instead")]
     pub fn wrap<U>(self, mw: U) -> Scope<Err, WebStack<M, U, Err>, T> {
         self.middleware(mw)
     }


### PR DESCRIPTION
## Description

The [`wrap()`](https://github.com/ntex-rs/ntex/blob/5861e39fb726b6ca4bb2b524720ca37f378a9e01/ntex/src/web/app.rs#L447C1-L451C6) method was deprecated in the commit 3ad5b20 without an explicit alternative provided.

## Changes

- Added `since` and `note` properties to the `#[deprecated]` attribute.