### PR TITLE
fix: add missing must use attribute on into static method

### DIFF
--- a/ntex-service/src/cfg.rs
+++ b/ntex-service/src/cfg.rs
@@ -148,7 +148,7 @@ impl<T: Configuration> Cfg<T> {
 
     #[doc(hidden)]
     #[deprecated(since = "4.5.0")]
-	#[must_use]
+    #[must_use]
     pub fn into_static(&self) -> Cfg<T> {
         self.ctx().get()
     }


### PR DESCRIPTION
Fixes:

```
error: missing `#[must_use]` attribute on a method returning `Self`
Error:    --> ntex-service/src/cfg.rs:151:5
    |
151 | /     pub fn into_static(&self) -> Cfg<T> {
152 | |         self.ctx().get()
153 | |     }
    | |_____^
    |
    = help: consider adding the `#[must_use]` attribute to the method or directly to the `Self` type
    = help: for further information visit [https://rust-lang.github.io/rust-clippy/rust-1.93.0/](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#return_self_not_must_use)
```