### PR TITLE
Upgrade the oneshot dependency to version 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ itoa = "1.0.15"
 libc = "0.2.164"
 log = "0.4"
 mime = "0.3"
-oneshot = "0.1"
+oneshot = { version = "0.2.1", features = ["std", "async"] }
 openssl = "0.10"
 tls_openssl = { version = "0.10", package = "openssl" }
 percent-encoding = "2.3"

--- a/ntex-rt/src/arbiter.rs
+++ b/ntex-rt/src/arbiter.rs
@@ -259,7 +259,7 @@ impl Arbiter {
         R: Future<Output = O> + 'static,
         O: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = oneshot::async_channel();
         let _ = self
             .sender
             .try_send(ArbiterCommand::ExecuteFn(Box::new(move || {
@@ -283,7 +283,7 @@ impl Arbiter {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = oneshot::async_channel();
         let _ = self
             .sender
             .try_send(ArbiterCommand::ExecuteFn(Box::new(move || {

--- a/ntex-rt/src/pool.rs
+++ b/ntex-rt/src/pool.rs
@@ -19,7 +19,7 @@ impl fmt::Display for BlockingError {
 
 #[derive(Debug)]
 pub struct BlockingResult<T> {
-    rx: Option<oneshot::Receiver<Result<T, Box<dyn Any + Send>>>>,
+    rx: Option<oneshot::AsyncReceiver<Result<T, Box<dyn Any + Send>>>>,
 }
 
 type BoxedDispatchable = Box<dyn Dispatchable + Send>;
@@ -96,7 +96,7 @@ impl ThreadPool {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = oneshot::async_channel();
         let f = Box::new(move || {
             let result = panic::catch_unwind(panic::AssertUnwindSafe(f));
             let _ = tx.send(result);

--- a/ntex-rt/src/rt_compio.rs
+++ b/ntex-rt/src/rt_compio.rs
@@ -47,7 +47,7 @@ impl std::error::Error for JoinError {}
 #[derive(Debug)]
 enum Either<T> {
     Compio(compio_runtime::JoinHandle<T>),
-    Spawn(oneshot::Receiver<T>),
+    Spawn(oneshot::AsyncReceiver<T>),
 }
 
 #[derive(Debug)]
@@ -123,7 +123,7 @@ impl Handle {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = oneshot::async_channel();
 
         let _ = self
             .0

--- a/ntex-rt/src/rt_tokio.rs
+++ b/ntex-rt/src/rt_tokio.rs
@@ -46,7 +46,7 @@ impl std::error::Error for JoinError {}
 #[derive(Debug)]
 enum Either<T> {
     Task(tok_io::task::JoinHandle<T>),
-    Spawn(oneshot::Receiver<T>),
+    Spawn(oneshot::AsyncReceiver<T>),
 }
 
 #[derive(Debug)]
@@ -125,7 +125,7 @@ impl Handle {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = oneshot::async_channel();
 
         let _ = self
             .0

--- a/ntex-server/src/server.rs
+++ b/ntex-server/src/server.rs
@@ -17,7 +17,7 @@ pub(crate) struct ServerShared {
 pub struct Server<T> {
     shared: Arc<ServerShared>,
     cmd: Sender<ServerCommand<T>>,
-    stop: Option<oneshot::Receiver<()>>,
+    stop: Option<oneshot::AsyncReceiver<()>>,
 }
 
 impl<T> Server<T> {
@@ -105,7 +105,7 @@ impl<T> Future for Server<T> {
         let this = self.get_mut();
 
         if this.stop.is_none() {
-            let (tx, rx) = oneshot::channel();
+            let (tx, rx) = oneshot::async_channel();
             if this.cmd.try_send(ServerCommand::NotifyStopped(tx)).is_err() {
                 return Poll::Ready(Ok(()));
             }

--- a/ntex-server/src/wrk.rs
+++ b/ntex-server/src/wrk.rs
@@ -74,7 +74,7 @@ impl<T> PartialEq for Worker<T> {
 ///
 /// Stop future resolves when worker completes processing
 /// incoming items and stop arbiter
-pub struct WorkerStop(oneshot::Receiver<bool>);
+pub struct WorkerStop(oneshot::AsyncReceiver<bool>);
 
 impl<T> Worker<T> {
     /// Start worker.
@@ -164,7 +164,7 @@ impl<T> Worker<T> {
     ///
     /// If timeout value is zero, force shutdown worker
     pub fn stop(&self, timeout: Millis) -> WorkerStop {
-        let (result, rx) = oneshot::channel();
+        let (result, rx) = oneshot::async_channel();
         let _ = self.tx2.try_send(Shutdown { timeout, result });
         WorkerStop(rx)
     }

--- a/ntex/tests/http_openssl.rs
+++ b/ntex/tests/http_openssl.rs
@@ -436,7 +436,7 @@ impl Drop for SetOnDrop {
 async fn test_h2_client_drop() -> io::Result<()> {
     let count = Arc::new(AtomicUsize::new(0));
     let count2 = count.clone();
-    let (tx, rx) = ::oneshot::channel();
+    let (tx, rx) = ::oneshot::async_channel();
     let tx = Arc::new(Mutex::new(Some(tx)));
 
     let srv = test_server(async move || {


### PR DESCRIPTION
Hi! Author and maintainer of `oneshot` here!

I just released version [0.2.1 of oneshot](https://crates.io/crates/oneshot/0.2.1). I saw from the reverse dependency section on crates.io that you use `oneshot`. So I wanted to reach out and help provide an upgrade for you! Depending on which `0.1.x` version you or your users are using, they might have race conditions. This was fixed in `0.1.12` already. But the `0.2.0` release contains lots of code cleanups and some minor breaking changes as well.
