### PR TITLE
Configure web test server port

### DIFF
--- a/ntex/src/web/test.rs
+++ b/ntex/src/web/test.rs
@@ -865,6 +865,7 @@ impl TestServerConfig {
         self
     }
 
+    #[must_use]
     /// Set server port. By default, test server binds to a random port assigned by OS.
     pub fn port(mut self, port: u16) -> Self {
         self.port = port;


### PR DESCRIPTION
Sometimes you need to know the port ahead of time, before starting the test server, or you simply want to supply your own but retain all of the nice testing helpers.

ATM, you have to do too much to assemble a test server with a custom port - why not simply configure it.

```rs
#[ntex::test]
async fn test_example() {
    let mut srv = test::server_with(test::config().h1().port(4000), ||
        App::new().service(web::resource("/").to(my_handler))
    );

    let req = srv.get("/");
    let response = req.send().await.unwrap();
    assert!(response.status().is_success());
}
```