### PR TITLE
Reset method of pooled RequestHead; ws client could send non-GET handshake

### DIFF
--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [3.9.8] - 2026-06-xx
+
+* Reset method of pooled `RequestHead` on release; ws client could send a recycled
+  non-GET method (e.g. POST) in the handshake request after the worker thread served
+  an HTTP request with that method
+
 ## [3.9.7] - 2026-06-11
 
 * HTTP/1 client silently truncates the auto-generated Host header #894

--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -6,6 +6,9 @@
   non-GET method (e.g. POST) in the handshake request after the worker thread served
   an HTTP request with that method
 
+* Include the received status code in `WsClientError::InvalidResponseStatus` display
+  message
+
 ## [3.9.7] - 2026-06-11
 
 * HTTP/1 client silently truncates the auto-generated Host header #894

--- a/ntex/src/http/message.rs
+++ b/ntex/src/http/message.rs
@@ -101,7 +101,6 @@ impl Head for RequestHead {
     fn clear(&mut self) {
         self.io = CurrentIo::None;
         self.flags = Flags::empty();
-        self.method = Method::default();
         self.version = Version::HTTP_11;
         self.headers.clear();
         self.extensions.get_mut().clear();

--- a/ntex/src/http/message.rs
+++ b/ntex/src/http/message.rs
@@ -101,6 +101,7 @@ impl Head for RequestHead {
     fn clear(&mut self) {
         self.io = CurrentIo::None;
         self.flags = Flags::empty();
+        self.method = Method::default();
         self.version = Version::HTTP_11;
         self.headers.clear();
         self.extensions.get_mut().clear();

--- a/ntex/src/ws/client.rs
+++ b/ntex/src/ws/client.rs
@@ -14,7 +14,7 @@ use nanorand::{Rng, WyRand};
 use crate::client::{ClientCodec, ClientConfig, ClientRawRequest, ClientResponse};
 use crate::connect::{Connect, ConnectError, Connector};
 use crate::http::header::{self, AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
-use crate::http::{ConnectionType, Message, RequestHead, StatusCode, Uri};
+use crate::http::{ConnectionType, Message, Method, RequestHead, StatusCode, Uri};
 use crate::http::{body::BodySize, error::HttpError};
 use crate::io::{Base, DispatchItem, Dispatcher, Filter, Io, Layer, Reason, Sealed};
 use crate::service::{IntoService, Pipeline, apply_fn, fn_service};
@@ -279,6 +279,9 @@ impl WsClientBuilder<Base, ()> {
         <Uri as TryFrom<U>>::Error: Into<HttpError>,
     {
         let mut head = Message::<RequestHead>::new();
+        // the message pool may return a recycled head whose method is not GET
+        // (e.g. previously used by the HTTP/1 server dispatcher for a POST request)
+        head.method = Method::GET;
         let err = match Uri::try_from(uri) {
             Ok(uri) => {
                 head.uri = uri;
@@ -981,5 +984,21 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[crate::rt_test]
+    async fn pooled_request_head_method_is_get() {
+        // a request head released back to the thread-local message pool keeps its
+        // method (e.g. POST from the HTTP/1 server dispatcher); a ws client built
+        // from such a recycled head must still send a GET handshake
+        let mut head = Message::<RequestHead>::new();
+        head.method = Method::POST;
+        drop(head);
+
+        let client = WsClient::builder("http://localhost")
+            .build(SharedCfg::default())
+            .await
+            .unwrap();
+        assert_eq!(client.head.method, Method::GET);
     }
 }

--- a/ntex/src/ws/error.rs
+++ b/ntex/src/ws/error.rs
@@ -95,7 +95,7 @@ pub enum WsClientError {
         DecodeError,
     ),
     /// Invalid response status
-    #[error("Invalid response status")]
+    #[error("Invalid response status: {0}")]
     InvalidResponseStatus(StatusCode),
     /// Invalid upgrade header
     #[error("Invalid upgrade header")]

--- a/ntex/tests/web_ws.rs
+++ b/ntex/tests/web_ws.rs
@@ -81,14 +81,59 @@ async fn web_no_ws() {
     })
     .await;
 
+    let err = srv.ws().await.err().unwrap();
     assert!(matches!(
-        srv.ws().await.err().unwrap(),
+        err,
         WsClientError::InvalidResponseStatus(StatusCode::OK)
     ));
+    assert_eq!(err.to_string(), "Invalid response status: 200 OK");
+
+    let err = srv.ws_at("/ws_error").await.err().unwrap();
     assert!(matches!(
-        srv.ws_at("/ws_error").await.err().unwrap(),
+        err,
         WsClientError::InvalidResponseStatus(StatusCode::INTERNAL_SERVER_ERROR)
     ));
+    assert_eq!(
+        err.to_string(),
+        "Invalid response status: 500 Internal Server Error"
+    );
+}
+
+#[ntex::test]
+async fn web_ws_after_pooled_post_request() {
+    let srv = test::server(async || {
+        App::new()
+            .service(
+                web::resource("/").route(web::to(|req: HttpRequest| async move {
+                    ws::start::<_, _, &str, web::Error>(
+                        req,
+                        None,
+                        fn_factory_with_config(|_| async {
+                            Ok::<_, web::Error>(fn_service(service))
+                        }),
+                    )
+                    .await
+                })),
+            )
+            .service(
+                web::resource("/post")
+                    .route(web::post().to(|| async { HttpResponse::Ok() })),
+            )
+    })
+    .await;
+
+    // a completed POST request releases its RequestHead back to the
+    // thread-local message pool; a ws client built afterwards on the same
+    // thread must not reuse the recycled POST method for its handshake
+    let res = srv.post("/post").send().await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let (io, codec, _) = srv.ws().await.unwrap().into_inner();
+    io.send(ws::Message::Text(ByteString::from_static("text")), &codec)
+        .await
+        .unwrap();
+    let item = io.recv(&codec).await.unwrap().unwrap();
+    assert_eq!(item, ws::Frame::Text(Bytes::from_static(b"text")));
 }
 
 #[ntex::test]


### PR DESCRIPTION
## Summary

`ws::WsClient` can send a **non-GET method in the websocket handshake request** when it is built on a thread that previously processed an HTTP request with a different method. Servers correctly reject such handshakes with a non-101 status (e.g. Spring/Tomcat responds `404`/`405`), which surfaces as `WsClientError::InvalidResponseStatus`.

## How we hit this

We run a GraphQL federation gateway (built on [hive-router](https://github.com/graphql-hive/router), which uses ntex) that opens a websocket connection to an upstream service for every GraphQL subscription. In production, subscriptions failed intermittently — and under load almost always — with:

```
Failed to connect WebSocket to 'ws://<upstream>/subscriptions': WebSocket client error: Invalid response status
```

The upstream service was healthy: manual handshakes (curl with `Upgrade: websocket`) succeeded 40/40 from the same host, while the router's connects kept failing. The failures appeared random — same code, same endpoint, different outcome per attempt.

## Investigation

Putting a logging TCP proxy between the router and the upstream finally showed the difference between a succeeding and a failing connect:

```
# success
GET /subscriptions HTTP/1.1
connection: upgrade
upgrade: websocket
...
HTTP/1.1 101

# failure
POST /subscriptions HTTP/1.1
connection: upgrade
upgrade: websocket
...
HTTP/1.1 404
```

The client was sending the upgrade request with method `POST`.

## Root cause

`RequestHead` objects are recycled through a thread-local message pool (`REQUEST_POOL` in `src/http/message.rs`) shared by everything on that thread, including the HTTP/1 server dispatcher and `WsClientBuilder`:

1. The server dispatcher parses an incoming request into a pooled head and writes its method (`h1/decoder.rs`). When the request completes, the head is released back to the pool via `Head::clear()`.
2. `RequestHead::clear()` resets `io`, `flags`, `version`, `headers` and `extensions` — but **not `method`**.
3. `WsClientBuilder::new()` takes a head from the pool and never sets the method, relying on the default `GET` — which only holds for a freshly allocated head.

So after a worker thread serves e.g. a `POST` request, the next `WsClient` built on that thread sends `POST` in its handshake. Whether you get `GET` or `POST` depends on the per-thread LIFO pool state, which is why the failures look random. Any application that serves HTTP traffic and opens ws client connections on the same runtime is affected; in our gateway (where nearly all served traffic is `POST`) the failure rate was close to 100% under load. The server dispatcher always overwrites the method, which is why this never shows up server-side — the ws client is the one consumer relying on the default.

## Fix

- `RequestHead::clear()` now resets `method` to `Method::default()`, matching `RequestHead::default()`.
- `WsClientBuilder::new()` additionally sets `head.method = Method::GET` explicitly, since RFC 6455 requires the handshake to be a GET request regardless of where the head came from.

## Debuggability

`WsClientError::InvalidResponseStatus` now includes the received status code in its display output (`Invalid response status: 404 Not Found` instead of `Invalid response status`). The status was already captured in the variant but hidden from the message, which made this considerably harder to diagnose than it needed to be.

## Tests

- `ws::client::tests::pooled_request_head_method_is_get` — unit test: poisons the thread-local pool with a `POST` head and asserts a ws client built afterwards uses `GET`.
- `web_ws_after_pooled_post_request` (tests/web_ws.rs) — end-to-end regression: completes a real `POST` request, then performs a full ws handshake + echo exchange on the same thread.
- `web_no_ws` — extended to assert the exact display output of `InvalidResponseStatus`.

Both new tests were verified to fail against the unfixed code and pass with the fix.
