### PR TITLE
Clear pooled response extensions

### DIFF
--- a/ntex/src/http/message.rs
+++ b/ntex/src/http/message.rs
@@ -367,6 +367,7 @@ impl Head for ResponseHead {
         self.headers.clear();
         self.io = CurrentIo::None;
         self.flags = Flags::empty();
+        self.extensions.get_mut().clear();
     }
 
     fn with_pool<F, R>(f: F) -> R

--- a/ntex/tests/response_pool.rs
+++ b/ntex/tests/response_pool.rs
@@ -1,0 +1,11 @@
+use ntex::http::{Response, StatusCode};
+
+#[test]
+fn response_extensions_are_cleared_when_reused_from_pool() {
+    let resp = Response::new(StatusCode::OK);
+    resp.extensions_mut().insert(42usize);
+    drop(resp);
+
+    let resp = Response::new(StatusCode::OK);
+    assert!(resp.extensions().get::<usize>().is_none());
+}


### PR DESCRIPTION
## Summary

Fixes a pooled `ResponseHead` reuse bug where response extensions could survive after a response was dropped, then appear on a later unrelated response allocated from the thread-local response pool.

## Root Cause

`Message<ResponseHead>` returns heads to the response pool on drop and calls `ResponseHead::clear()` before reuse. Unlike `RequestHead::clear()`, `ResponseHead::clear()` reset the reason, headers, IO state, and flags, but did not clear `extensions`.

That allowed values inserted through `Response::extensions_mut()` to leak into the next response allocated on the same worker thread. One practical case is web response encoding metadata: compression middleware reads response extensions to decide whether an explicit encoding override exists.

## Changes

- Clear `ResponseHead.extensions` in `ResponseHead::clear()`.
- Add a regression test that stores a typed extension on one response, drops it, creates another response, and asserts the extension is gone.

## Validation

- `cargo fmt --check`
- `cargo test --offline -p ntex --test response_pool response_extensions_are_cleared_when_reused_from_pool`

## Risk

Low. This only removes stale per-response extension data during pooled head cleanup. It makes response head reuse match the existing request head cleanup behavior.
