### PR TITLE
Fix rustls filter close_notify handling and read-path record flushing

### DIFF
--- a/ntex-tls/CHANGES.md
+++ b/ntex-tls/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [3.6.3] - 2026-06-12
+
+* rustls: Send close_notify on filter shutdown
+
+* rustls: Flush tls records generated while processing incoming data (e.g. KeyUpdate responses)
+
+* rustls: Start io shutdown when peer sends close_notify
+
 ## [3.6.2] - 2026-03-22
 
 * Init connect/accept process before adding to filters

--- a/ntex-tls/src/rustls/client.rs
+++ b/ntex-tls/src/rustls/client.rs
@@ -1,5 +1,5 @@
 //! An implementation of SSL streams for ntex backed by OpenSSL
-use std::{any, cell::RefCell, io, sync::Arc};
+use std::{any, cell::RefCell, io, sync::Arc, task::Poll};
 
 use ntex_io::{Filter, FilterBuf, FilterLayer, Io, Layer};
 use tls_rustls::{ClientConfig, ClientConnection, pki_types::ServerName};
@@ -23,6 +23,10 @@ impl FilterLayer for TlsClientFilter {
 
     fn process_write_buf(&self, buf: &FilterBuf<'_>) -> io::Result<()> {
         Stream::new(&mut *self.session.borrow_mut()).process_write_buf(buf)
+    }
+
+    fn shutdown(&self, buf: &FilterBuf<'_>) -> io::Result<Poll<()>> {
+        Stream::new(&mut *self.session.borrow_mut()).shutdown(buf)
     }
 }
 

--- a/ntex-tls/src/rustls/server.rs
+++ b/ntex-tls/src/rustls/server.rs
@@ -1,5 +1,5 @@
 //! An implementation of SSL streams for ntex backed by OpenSSL
-use std::{any, cell::RefCell, io, sync::Arc};
+use std::{any, cell::RefCell, io, sync::Arc, task::Poll};
 
 use ntex_io::{Filter, FilterBuf, FilterLayer, Io, Layer};
 use ntex_util::{time, time::Millis};
@@ -35,6 +35,10 @@ impl FilterLayer for TlsServerFilter {
 
     fn process_write_buf(&self, buf: &FilterBuf<'_>) -> io::Result<()> {
         Stream::new(&mut *self.session.borrow_mut()).process_write_buf(buf)
+    }
+
+    fn shutdown(&self, buf: &FilterBuf<'_>) -> io::Result<Poll<()>> {
+        Stream::new(&mut *self.session.borrow_mut()).shutdown(buf)
     }
 }
 

--- a/ntex-tls/src/rustls/stream.rs
+++ b/ntex-tls/src/rustls/stream.rs
@@ -59,7 +59,7 @@ where
     }
 
     pub(crate) fn process_read_buf(&mut self, buf: &FilterBuf<'_>) -> io::Result<()> {
-        buf.with_read_buffers(|r_src, r_dst| {
+        let result = buf.with_read_buffers(|r_src, r_dst| {
             if let Some(src) = r_src {
                 loop {
                     match self.session.read_tls(src) {
@@ -92,7 +92,24 @@ where
             } else {
                 Ok(())
             }
-        })
+        });
+
+        // flush tls records generated while processing incoming data
+        // (e.g. KeyUpdate responses), original error takes priority;
+        // during handshake flushing is driven by the handshake helper
+        if !self.session.is_handshaking() {
+            // materialize tls records queued by the session, rustls keeps
+            // KeyUpdate responses outside of its sendable tls buffer until
+            // the next plaintext write; an empty write is a no-op otherwise
+            let _ = self.session.writer().write(&[]);
+
+            if self.session.wants_write() {
+                let flushed = self.write_tls_records(buf);
+                result?;
+                return flushed;
+            }
+        }
+        result
     }
 
     pub(crate) fn process_write_buf(&mut self, buf: &FilterBuf<'_>) -> io::Result<()> {

--- a/ntex-tls/src/rustls/stream.rs
+++ b/ntex-tls/src/rustls/stream.rs
@@ -1,3 +1,4 @@
+use std::task::Poll;
 use std::{any, cell::RefCell, io, io::Write, ops::Deref, ops::DerefMut};
 
 use ntex_bytes::{BufMut, BytePages};
@@ -123,6 +124,34 @@ where
                 return Ok(());
             }
         })
+    }
+
+    /// Write pending tls records to the output buffer
+    fn write_tls_records(&mut self, buf: &FilterBuf<'_>) -> io::Result<()> {
+        buf.with_write_buffers(|_, w_dst| {
+            let mut wrp = Wrapper { w_dst, buf };
+            while self.session.wants_write() {
+                self.session.write_tls(&mut wrp)?;
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn shutdown(&mut self, buf: &FilterBuf<'_>) -> io::Result<Poll<()>> {
+        // drain pending application data into tls records first
+        self.process_write_buf(buf)?;
+
+        // queue close_notify alert (idempotent, may be called on every poll)
+        self.session.send_close_notify();
+
+        // write pending tls records (incl. close_notify) to the output buffer
+        self.write_tls_records(buf)?;
+
+        if self.session.wants_write() {
+            Ok(Poll::Pending)
+        } else {
+            Ok(Poll::Ready(()))
+        }
     }
 }
 

--- a/ntex-tls/src/rustls/stream.rs
+++ b/ntex-tls/src/rustls/stream.rs
@@ -79,6 +79,10 @@ where
                             unsafe { &mut *(&raw mut *r_dst.chunk_mut() as *mut [u8]) };
                         let v = io::Read::read(&mut self.session.reader(), chunk)?;
                         unsafe { r_dst.advance_mut(v) };
+                    } else if state.peer_has_closed() {
+                        // peer sent close_notify, start graceful shutdown
+                        buf.io().close();
+                        break;
                     } else if src.is_empty() {
                         break;
                     }

--- a/ntex/tests/connect.rs
+++ b/ntex/tests/connect.rs
@@ -297,12 +297,7 @@ async fn test_rustls_peer_close_notify_closes_io() {
                 io.send(msg, &BytesCodec).await.unwrap();
 
                 // wait until the peer disconnects
-                loop {
-                    match io.recv(&BytesCodec).await {
-                        Ok(Some(_)) => continue,
-                        Ok(None) | Err(_) => break,
-                    }
-                }
+                while let Ok(Some(_)) = io.recv(&BytesCodec).await {}
                 Ok::<_, io::Error>(())
             })
             .map_init_err(|_| ()),
@@ -352,9 +347,7 @@ async fn test_rustls_peer_close_notify_closes_io() {
                 if e.kind() == io::ErrorKind::WouldBlock
                     || e.kind() == io::ErrorKind::TimedOut =>
             {
-                panic!(
-                    "server did not close connection after receiving close_notify: {e}"
-                );
+                panic!("server did not close connection after receiving close_notify: {e}");
             }
             // connection reset also indicates closure
             Err(_) => break,

--- a/ntex/tests/connect.rs
+++ b/ntex/tests/connect.rs
@@ -418,6 +418,94 @@ async fn test_rustls_shutdown_sends_close_notify() {
     }
 }
 
+#[cfg(feature = "rustls")]
+#[ntex::test]
+async fn test_rustls_keyupdate_response_flushed() {
+    use std::io::{Read, Write};
+    use std::sync::Arc;
+
+    use ntex::server::rustls;
+    use tls_rustls::pki_types::ServerName;
+
+    let srv = test_server(async || {
+        chain_factory(
+            rustls::TlsAcceptor::new(rustls_utils::tls_acceptor_arc()).map_err(|e| {
+                log::error!("tls negotiation is failed: {e:?}");
+                e
+            }),
+        )
+        .and_then(
+            fn_service(|io: Io<_>| async move {
+                // echo frames, then sit idle waiting for more data
+                while let Some(item) = io.recv(&BytesCodec).await.unwrap() {
+                    io.send(item, &BytesCodec).await.unwrap();
+                }
+                Ok::<_, io::Error>(())
+            })
+            .map_init_err(|_| ()),
+        )
+    });
+
+    // raw blocking rustls client, tls 1.3 only (KeyUpdate requires it)
+    let config = tls_rustls::ClientConfig::builder_with_protocol_versions(&[
+        &tls_rustls::version::TLS13,
+    ])
+    .dangerous()
+    .with_custom_certificate_verifier(Arc::new(rustls_utils::NoCertificateVerification))
+    .with_no_client_auth();
+    let mut conn = tls_rustls::ClientConnection::new(
+        Arc::new(config),
+        ServerName::try_from("localhost").unwrap(),
+    )
+    .unwrap();
+
+    let mut tcp = std::net::TcpStream::connect(srv.addr()).unwrap();
+    tcp.set_nodelay(true).unwrap();
+    tcp.set_read_timeout(Some(std::time::Duration::from_secs(15)))
+        .unwrap();
+    conn.complete_io(&mut tcp).unwrap();
+    assert!(!conn.is_handshaking());
+
+    // echo round-trip to make sure the connection is fully operational
+    conn.writer().write_all(b"ping").unwrap();
+    while conn.wants_write() {
+        conn.write_tls(&mut tcp).unwrap();
+    }
+    let mut echo = Vec::new();
+    while echo.len() < 4 {
+        if conn.read_tls(&mut tcp).unwrap() == 0 {
+            panic!("server closed connection before echo");
+        }
+        let state = conn.process_new_packets().unwrap();
+        let n = state.plaintext_bytes_to_read();
+        if n > 0 {
+            let mut chunk = vec![0u8; n];
+            conn.reader().read_exact(&mut chunk).unwrap();
+            echo.extend_from_slice(&chunk);
+        }
+    }
+    assert_eq!(echo, b"ping");
+
+    // request a key update; the server must answer with its own KeyUpdate
+    conn.refresh_traffic_keys().unwrap();
+    while conn.wants_write() {
+        conn.write_tls(&mut tcp).unwrap();
+    }
+
+    // the connection is otherwise idle; the server's KeyUpdate response
+    // (generated while processing incoming data) must still reach the wire
+    tcp.set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    match conn.read_tls(&mut tcp) {
+        Ok(n) if n > 0 => {
+            conn.process_new_packets().unwrap();
+        }
+        other => panic!(
+            "server did not flush KeyUpdate response generated during read processing: {other:?}"
+        ),
+    }
+}
+
 #[ntex::test]
 async fn test_static_str() {
     let srv = test_server(async || {

--- a/ntex/tests/connect.rs
+++ b/ntex/tests/connect.rs
@@ -362,6 +362,62 @@ async fn test_rustls_peer_close_notify_closes_io() {
     }
 }
 
+#[cfg(feature = "rustls")]
+#[ntex::test]
+async fn test_rustls_shutdown_sends_close_notify() {
+    use std::io::{Read, Write};
+    use std::sync::Arc;
+
+    use ntex::server::rustls;
+
+    let srv = test_server(async || {
+        chain_factory(
+            rustls::TlsAcceptor::new(rustls_utils::tls_acceptor_arc()).map_err(|e| {
+                log::error!("tls negotiation is failed: {e:?}");
+                e
+            }),
+        )
+        .and_then(
+            fn_service(|io: Io<_>| async move {
+                let item = io.recv(&BytesCodec).await.unwrap().unwrap();
+                io.send(item, &BytesCodec).await.unwrap();
+                // graceful shutdown, must deliver TLS close_notify to the peer
+                io.shutdown().await.unwrap();
+                Ok::<_, io::Error>(())
+            })
+            .map_init_err(|_| ()),
+        )
+    });
+    let addr = srv.addr();
+
+    // raw blocking rustls client
+    let cfg = Arc::new(rustls_utils::tls_connector());
+    let name = tls_rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let mut conn = tls_rustls::ClientConnection::new(cfg, name).unwrap();
+    let mut sock = std::net::TcpStream::connect(addr).unwrap();
+    sock.set_read_timeout(Some(std::time::Duration::from_secs(10)))
+        .unwrap();
+    let mut tls = tls_rustls::Stream::new(&mut conn, &mut sock);
+
+    tls.write_all(b"hello").unwrap();
+    tls.flush().unwrap();
+
+    let mut echo = [0u8; 5];
+    tls.read_exact(&mut echo).unwrap();
+    assert_eq!(&echo, b"hello");
+
+    // keep reading until EOF; a clean Ok(0) means close_notify was received,
+    // an UnexpectedEof error means the peer closed without sending close_notify
+    let mut tmp = [0u8; 1024];
+    loop {
+        match tls.read(&mut tmp) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(e) => panic!("expected clean EOF (close_notify), got error: {e:?}"),
+        }
+    }
+}
+
 #[ntex::test]
 async fn test_static_str() {
     let srv = test_server(async || {

--- a/ntex/tests/connect.rs
+++ b/ntex/tests/connect.rs
@@ -274,6 +274,94 @@ async fn test_rustls_string() {
     assert!(io.recv(&BytesCodec).await.unwrap().is_none());
 }
 
+#[cfg(feature = "rustls")]
+#[ntex::test]
+async fn test_rustls_peer_close_notify_closes_io() {
+    use std::io::{Read as _, Write as _};
+    use std::{sync::Arc, time::Duration};
+
+    use ntex::server::rustls;
+    use tls_rustls::pki_types::ServerName;
+
+    let srv = test_server(async || {
+        chain_factory(
+            rustls::TlsAcceptor::new(rustls_utils::tls_acceptor_arc()).map_err(|e| {
+                log::error!("tls negotiation is failed: {e:?}");
+                e
+            }),
+        )
+        .and_then(
+            fn_service(|io: Io<_>| async move {
+                // echo round-trip proves the data path works
+                let msg = io.recv(&BytesCodec).await.unwrap().unwrap();
+                io.send(msg, &BytesCodec).await.unwrap();
+
+                // wait until the peer disconnects
+                loop {
+                    match io.recv(&BytesCodec).await {
+                        Ok(Some(_)) => continue,
+                        Ok(None) | Err(_) => break,
+                    }
+                }
+                Ok::<_, io::Error>(())
+            })
+            .map_init_err(|_| ()),
+        )
+    });
+
+    // raw blocking rustls client
+    let config = Arc::new(rustls_utils::tls_connector());
+    let mut conn = tls_rustls::ClientConnection::new(
+        config,
+        ServerName::try_from("localhost").unwrap(),
+    )
+    .unwrap();
+    let mut tcp = std::net::TcpStream::connect(srv.addr()).unwrap();
+
+    // handshake + echo round-trip
+    {
+        let mut tls = tls_rustls::Stream::new(&mut conn, &mut tcp);
+        tls.write_all(b"hello").unwrap();
+        tls.flush().unwrap();
+        let mut echo = [0u8; 5];
+        tls.read_exact(&mut echo).unwrap();
+        assert_eq!(&echo, b"hello");
+    }
+
+    // send TLS close_notify, but keep the tcp stream fully open
+    // (no shutdown of the write side - tls level half-close only);
+    // queue one more plaintext record so that plaintext and close_notify
+    // arrive in the same batch
+    conn.writer().write_all(b"bye").unwrap();
+    conn.send_close_notify();
+    while conn.wants_write() {
+        conn.write_tls(&mut tcp).unwrap();
+    }
+    tcp.flush().unwrap();
+
+    // server must close the connection in a timely manner
+    tcp.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+    let mut buf = [0u8; 4096];
+    loop {
+        match tcp.read(&mut buf) {
+            // EOF, server closed the connection
+            Ok(0) => break,
+            // tls records (e.g. server's close_notify alert), keep reading
+            Ok(_) => continue,
+            Err(ref e)
+                if e.kind() == io::ErrorKind::WouldBlock
+                    || e.kind() == io::ErrorKind::TimedOut =>
+            {
+                panic!(
+                    "server did not close connection after receiving close_notify: {e}"
+                );
+            }
+            // connection reset also indicates closure
+            Err(_) => break,
+        }
+    }
+}
+
 #[ntex::test]
 async fn test_static_str() {
     let srv = test_server(async || {


### PR DESCRIPTION
## Summary

This PR fixes three related gaps in the rustls filter where it diverged from the (recently fixed) openssl filter's buffering and shutdown discipline. Each fix comes with a regression test that was verified to fail before the fix and pass after.

### 1. Send `close_notify` on filter shutdown

Neither `TlsServerFilter` nor `TlsClientFilter` implemented `FilterLayer::shutdown`, so a graceful shutdown closed the TCP connection without ever sending a TLS `close_notify` alert. Peers observed an unclean close:

```
UnexpectedEof: "peer closed connection without sending TLS close_notify"
```

Both filters now implement `shutdown`: drain pending application data, queue `close_notify` (idempotent in rustls), and write the remaining records to the output buffer — mirroring the openssl filter (`SslFilter::shutdown`). Per TLS 1.3 half-close semantics the filter does not wait for the peer's responding `close_notify`, so shutdown cannot stall on non-responding peers.

### 2. Flush TLS records generated while processing incoming data

`process_read_buf` called `read_tls`/`process_new_packets` but never `write_tls`, so TLS output generated during read processing stayed in the session's internal buffer until the next application write. On an idle connection, the response to a peer-initiated `KeyUpdate` was never sent and the peer could stall waiting for it. This is the same class of bug as the openssl filter buffering fix (#875).

`process_read_buf` now drains pending records into the output buffer at the end of read processing. Two implementation notes:

- rustls keeps the KeyUpdate response in a private buffer (`queued_key_update_message`) that is excluded from `wants_write()` until the next plaintext write; an empty `writer().write(&[])` materializes it and is otherwise a no-op (verified against rustls 0.23: empty payloads are dropped by `send_plain`/`ChunkVecBuffer::append` without emitting a record).
- The drain is skipped while `is_handshaking()`; handshake flushing continues to be driven by the `handshake()` helper. This is required because `Io::add_filter` discards the `FilterUpdates::wants_write` returned by its initial `process_read_buf` call, so a drain at filter-add time would strand the first flight (this may be worth addressing separately in ntex-io).

### 3. Start io shutdown when the peer sends `close_notify`

A peer that sent `close_notify` but kept the TCP connection open (TLS half-close) was never noticed: `process_read_buf` only inspected `plaintext_bytes_to_read()`, so the connection lingered until an unrelated timeout while a handler blocked in `recv()` waited indefinitely. The filter now checks `IoState::peer_has_closed()` once plaintext is drained and initiates a graceful shutdown via `io().close()` — mirroring the openssl filter's `ZERO_RETURN` handling. Plain TCP EOF does not trigger this path.

## Tests

Three new regression tests in `ntex/tests/connect.rs`, each proven to fail on the unmodified tree for the right reason (raw `std::net::TcpStream` + rustls clients so the assertions are made at the TLS protocol level, not through the ntex filter under test):

- `test_rustls_shutdown_sends_close_notify` — asserts the client sees a clean EOF (`Ok(0)`) instead of `UnexpectedEof` after server-side `io.shutdown()`.
- `test_rustls_keyupdate_response_flushed` — client requests a key update on an otherwise idle connection and asserts the server's KeyUpdate response arrives (previously: 5s read timeout).
- `test_rustls_peer_close_notify_closes_io` — client sends plaintext + `close_notify` in one batch with the TCP write side kept open, and asserts the server closes the connection promptly (previously: hang). Also covers the plaintext-and-close_notify-in-one-batch ordering.

All existing tests pass: `--test connect` (11), `--test http_rustls` (18, incl. h2 graceful shutdown), `--test http_client_rustls`, and `ntex-tls` package tests.

## Known limitation (out of scope)

Fatal alerts queued by `process_new_packets` on the error path still cannot reach the wire: `update_read_status` terminates the connection on filter error without flushing filter output. The drain code in this PR runs on the error path too, so alerts will be delivered if ntex-io ever flushes on terminate, but fixing that requires an ntex-io change.
