### PR TITLE
Do not drop buffered write tail during graceful shutdown under read b…

### DIFF
--- a/ntex-io/CHANGES.md
+++ b/ntex-io/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [Unreleased]
+
+* Do not abort the write-buffer flush during graceful shutdown when filter shutdown has completed but read backpressure is active; this dropped a buffered response tail
+
 ## [3.12.2] - 2026-05-22
 
 * Do not use invalid io while adding new filter

--- a/ntex-io/src/ctx.rs
+++ b/ntex-io/src/ctx.rs
@@ -283,7 +283,9 @@ impl IoContext {
         // filters are shutdown and write task is paused
         if ready && st.flags.is_write_paused() && !st.flags.is_wr_send_scheduled() {
             st.filters_stopped();
-        } else if st.flags.is_read_paused() || st.flags.is_read_ready_and_backpressure() {
+        } else if !ready
+            && (st.flags.is_read_paused() || st.flags.is_read_ready_and_backpressure())
+        {
             // if read buffer is not consumed it is unlikely
             // that filter will properly complete shutdown
             st.filters_stopped();

--- a/ntex-io/src/io.rs
+++ b/ntex-io/src/io.rs
@@ -1320,6 +1320,60 @@ mod tests {
     }
 
     #[ntex::test]
+    async fn shutdown_flushes_write_buf_with_read_backpressure() {
+        // Graceful shutdown must flush the pending write buffer even if
+        // the peer keeps sending data (read backpressure is enabled).
+        let (client, server) = IoTest::create();
+        // remote side does not accept any data yet, write task stalls
+        client.remote_buffer_cap(0);
+
+        let io = Io::new(
+            server,
+            SharedCfg::new("SRV").add(
+                IoConfig::default()
+                    .set_read_buf(8, 4, 16)
+                    .set_disconnect_timeout(ntex_util::time::Seconds(2)),
+            ),
+        );
+
+        // queue response data; remote is stalled so it stays in the write buffer
+        io.encode_slice(b"response-tail").unwrap();
+        sleep(Millis(50)).await;
+        assert_eq!(io.st().buffer.write_buf_size(), 13);
+
+        // peer keeps sending, crossing the read high watermark,
+        // read task gets paused with back-pressure enabled
+        client.write("0123456789");
+        sleep(Millis(50)).await;
+        assert!(io.flags().is_read_paused());
+        assert!(io.flags().is_rd_backpressure());
+        assert_eq!(io.st().buffer.write_buf_size(), 13);
+
+        // start graceful shutdown while the write buffer is not empty
+        io.close();
+        sleep(Millis(50)).await;
+
+        // peer starts draining the connection
+        client.remote_buffer_cap(1024);
+
+        // all previously queued data must be written before io stream is closed.
+        // Without the fix graceful shutdown completes immediately (read is paused
+        // with back-pressure), dropping the buffered write data, so the read here
+        // returns nothing instead of the queued response tail.
+        let data = ntex_util::time::timeout(Millis(2000), client.read())
+            .await
+            .expect("write buffer was dropped during shutdown")
+            .unwrap();
+        assert_eq!(&data[..], b"response-tail");
+
+        // the connection still closes gracefully afterwards (within the
+        // disconnect timeout) instead of hanging
+        ntex_util::time::timeout(Millis(4000), io.on_disconnect())
+            .await
+            .expect("io stream did not disconnect after flush");
+    }
+
+    #[ntex::test]
     async fn shutdown() {
         // layer drops all unprocessed data after filter shutdown
         #[derive(Debug)]


### PR DESCRIPTION
## Summary

During graceful shutdown, `IoContext::shutdown_filters` (`ntex-io/src/ctx.rs`) could mark the connection `IO_STOPPING` while there were still buffered write bytes that had not been flushed, silently dropping a response tail. This PR gates the offending branch so the flush completes first.

## The bug

`shutdown_filters` ends with a three-way decision:

```rust
if ready && st.flags.is_write_paused() && !st.flags.is_wr_send_scheduled() {
    st.filters_stopped();
} else if st.flags.is_read_paused() || st.flags.is_read_ready_and_backpressure() {
    // if read buffer is not consumed it is unlikely
    // that filter will properly complete shutdown
    st.filters_stopped();
} else {
    // filter shutdown timeout — keeps the connection alive while writes drain
}
```

Branch 2 calls `filters_stopped()` (which sets `IO_STOPPING`) whenever the read task is paused or under back-pressure — **regardless of whether filter shutdown actually completed (`ready`) and regardless of pending write bytes**. Once `IO_STOPPING` is set, `update_write_status` aborts the flush, because it checks `is_closed()` *before* the buffer-drain check. The buffered bytes are then discarded.

Per its own comment, branch 2 only exists for the case where filters *cannot* finish because the read buffer is not being consumed — i.e. `ready == false`. When filter shutdown has already completed (`ready == true`) but the write buffer is still draining, taking this branch is wrong: we should fall through to the timeout branch, which keeps the connection alive until the write buffer empties.

### Trigger

`Io::poll_shutdown` clears read flags when shutdown is initiated, so reaching this requires the read side to re-arm back-pressure during the close window — e.g. a peer that **keeps sending** while the server is closing. A concrete gateway-shaped case: rejecting a large upload with an error response + `Connection: close` while the client is still streaming the request body.

## The fix

Gate branch 2 on `!ready`:

```rust
} else if !ready
    && (st.flags.is_read_paused() || st.flags.is_read_ready_and_backpressure())
{
    st.filters_stopped();
}
```

One line; branch 1 and the timeout branch are unchanged.

## Tests

New regression test `shutdown_flushes_write_buf_with_read_backpressure` in `ntex-io/src/io.rs`:

- queues a write tail (`response-tail`) while the remote side accepts nothing, so it stays in the write buffer;
- writes data from the peer to cross the read high-watermark, pausing the read task with back-pressure;
- initiates `close()` while the write buffer is non-empty;
- lets the peer start draining and asserts the **full** tail arrives, then that the connection closes gracefully.

Verified to **fail without the fix** — the read times out and the test panics with `write buffer was dropped during shutdown` — and to **pass with it**.

> Note for downstream pinning: this is a HEAD-only bug (post-#877 io architecture). The 3.9.x line uses the pre-refactor shutdown path and is not affected by this exact branch.
