### PR TITLE
Update remove_all_items

### DIFF
--- a/ntex-rt/CHANGES.md
+++ b/ntex-rt/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [3.15.5] - 2026-07-14
+
+* `remove_all_items()` no longer holds refcell for duration of removal.
+
 ## [3.15.4] - 2026-06-25
 
 * Disable arbiter pings is interval is set to 0

--- a/ntex-rt/Cargo.toml
+++ b/ntex-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-rt"
-version = "3.15.4"
+version = "3.15.5"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "ntex runtime"
 keywords = ["network", "framework", "async", "futures"]

--- a/ntex-rt/src/arbiter.rs
+++ b/ntex-rt/src/arbiter.rs
@@ -343,6 +343,15 @@ where
 
 /// Remove all items from storage.
 pub fn remove_all_items() {
-    STORAGE.with(move |cell| cell.borrow_mut().clear());
+    STORAGE.with(move |cell| {
+        loop {
+            let mut items = cell.borrow_mut();
+            let Some(item) = items.drain().next() else {
+                break;
+            };
+            drop(items);
+            drop(item);
+        }
+    });
     System::remove_current();
 }


### PR DESCRIPTION
Currently remove_all_items will panic if the item it's removing has a drop function that accesses rt storage, this will let items access storage.