### PR TITLE
feat: add support for query http method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ futures = "0.3.31"
 futures-core = { version = "0.3.31", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 futures-timer = "3.0"
-http = "1.3.1"
+http = { version = "1", git = "https://github.com/hyperium/http" }
 httparse = "1.10.1"
 httpdate = "1.0"
 itoa = "1.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ futures = "0.3.31"
 futures-core = { version = "0.3.31", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 futures-timer = "3.0"
-http = { version = "1", git = "https://github.com/hyperium/http" }
+http = "1.5.0"
 httparse = "1.10.1"
 httpdate = "1.0"
 itoa = "1.0.18"

--- a/ntex-macros/src/lib.rs
+++ b/ntex-macros/src/lib.rs
@@ -178,9 +178,9 @@ pub fn web_patch(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// Create a route handler with `QUERY` method guard.
-/// 
+///
 /// Syntax: `#[query("path"[, attributes])]`
-/// 
+///
 /// Attributes are the same as in [query](attr.query.html)
 #[proc_macro_attribute]
 pub fn web_query(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/ntex-macros/src/lib.rs
+++ b/ntex-macros/src/lib.rs
@@ -177,6 +177,20 @@ pub fn web_patch(args: TokenStream, input: TokenStream) -> TokenStream {
     gen_code.generate()
 }
 
+/// Create a route handler with `QUERY` method guard.
+/// 
+/// Syntax: `#[query("path"[, attributes])]`
+/// 
+/// Attributes are the same as in [query](attr.query.html)
+#[proc_macro_attribute]
+pub fn web_query(args: TokenStream, input: TokenStream) -> TokenStream {
+    let gen_code = match route::Route::new(args, input, route::MethodType::Query) {
+        Ok(gen_code) => gen_code,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    gen_code.generate()
+}
+
 /// Marks async function to be executed by ntex system.
 ///
 /// ## Usage

--- a/ntex-macros/src/route.rs
+++ b/ntex-macros/src/route.rs
@@ -14,6 +14,7 @@ pub enum MethodType {
     Options,
     Trace,
     Patch,
+    Query,
 }
 
 impl MethodType {
@@ -28,6 +29,7 @@ impl MethodType {
             MethodType::Options => "Options",
             MethodType::Trace => "Trace",
             MethodType::Patch => "Patch",
+            MethodType::Query => "Query",
         }
     }
 }

--- a/ntex/src/client/mod.rs
+++ b/ntex/src/client/mod.rs
@@ -181,6 +181,15 @@ impl Client {
         self.request(Method::DELETE, url)
     }
 
+    /// Contruct HTTP *QUERY* request.
+    pub fn query<U>(&self, url: U) -> ClientRequest
+    where
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<HttpError>,
+    {
+        self.request(Method::QUERY, url)
+    }
+
     /// Construct HTTP *OPTIONS* request.
     pub fn options<U>(&self, url: U) -> ClientRequest
     where

--- a/ntex/src/client/mod.rs
+++ b/ntex/src/client/mod.rs
@@ -181,7 +181,7 @@ impl Client {
         self.request(Method::DELETE, url)
     }
 
-    /// Contruct HTTP *QUERY* request.
+    /// Construct HTTP *QUERY* request.
     pub fn query<U>(&self, url: U) -> ClientRequest
     where
         Uri: TryFrom<U>,

--- a/ntex/src/web/guard.rs
+++ b/ntex/src/web/guard.rs
@@ -311,6 +311,11 @@ pub fn Trace() -> MethodGuard {
     MethodGuard(Method::TRACE)
 }
 
+/// Predicate to match *QUERY* http method
+pub fn Query() -> MethodGuard {
+    MethodGuard(Method::QUERY)
+}
+
 /// Predicate to match specified http method
 pub fn Method(method: Method) -> MethodGuard {
     MethodGuard(method)
@@ -572,6 +577,12 @@ mod tests {
         assert!(Trace().check(r.head()));
         assert!(!Trace().check(req.head()));
         assert!(format!("{:?}", Trace()).contains("MethodGuard(TRACE)"));
+
+        let r = TestRequest::default()
+            .method(Method::QUERY)
+            .to_http_request();
+        assert!(Query().check(r.head()));
+        assert!(!Query().check(req.head()));
     }
 
     #[test]

--- a/ntex/src/web/test.rs
+++ b/ntex/src/web/test.rs
@@ -967,6 +967,11 @@ impl TestServer {
         self.client.options(self.url(path.as_ref()).as_str())
     }
 
+    /// Create `QUERY` request
+    pub fn query<S: AsRef<str>>(&self, path: S) -> ClientRequest {
+        self.client.query(self.url(path.as_ref()).as_str())
+    }
+
     /// Connect to test http server
     pub fn request<S: AsRef<str>>(&self, method: Method, path: S) -> ClientRequest {
         self.client.request(method, path.as_ref())

--- a/ntex/src/web/util.rs
+++ b/ntex/src/web/util.rs
@@ -190,6 +190,24 @@ pub fn head<Err: ErrorRenderer>() -> Route<Err> {
     method(Method::HEAD)
 }
 
+/// Create *route* with `QUERY` method guard.
+///
+/// ```rust
+/// use ntex::web;
+///
+/// let app = web::App::new().service(
+///     web::resource("/{project_id}")
+///         .route(web::query().to(|| async { web::HttpResponse::Ok() }))
+/// );
+/// ```
+///
+/// In the above example, one `QUERY` route gets added:
+///  * `/{project_id}`
+///
+pub fn query<Err: ErrorRenderer>() -> Route<Err> {
+    method(Method::QUERY)
+}
+
 /// Create *route* and add method guard.
 ///
 /// ```rust

--- a/ntex/tests/http_client.rs
+++ b/ntex/tests/http_client.rs
@@ -887,14 +887,13 @@ async fn test_query_method() {
     let srv = test::server(|| async {
         App::new().route(
             "/query",
-            web::query()
-                .to(|mut payload: web::types::Payload| async move {
-                    let mut bytes = BytesMut::new();
-                    while let Some(item) = ntex::util::stream_recv(&mut payload).await {
-                        bytes.extend_from_slice(&item.unwrap());
-                    }
-                    bytes
-                }),
+            web::query().to(|mut payload: web::types::Payload| async move {
+                let mut bytes = BytesMut::new();
+                while let Some(item) = ntex::util::stream_recv(&mut payload).await {
+                    bytes.extend_from_slice(&item.unwrap());
+                }
+                bytes
+            }),
         )
     })
     .await;

--- a/ntex/tests/http_client.rs
+++ b/ntex/tests/http_client.rs
@@ -879,3 +879,34 @@ async fn untruncated_host_header() {
 
     assert_eq!(received, format!("localhost:{port}"));
 }
+
+/// Test the newly added QUERY method.
+#[ntex::test]
+async fn test_query_method() {
+    use ntex::util::BytesMut;
+    let srv = test::server(|| async {
+        App::new().route(
+            "/query",
+            web::query()
+                .to(|mut payload: web::types::Payload| async move {
+                    let mut bytes = BytesMut::new();
+                    while let Some(item) = ntex::util::stream_recv(&mut payload).await {
+                        bytes.extend_from_slice(&item.unwrap());
+                    }
+                    bytes
+                }),
+        )
+    })
+    .await;
+
+    let test_body = Bytes::from_static(b"SuperBody");
+
+    let resp = srv
+        .query("/query")
+        .send_body(test_body.clone())
+        .await
+        .unwrap();
+    let body = resp.body().await.unwrap();
+
+    assert_eq!(test_body, body);
+}


### PR DESCRIPTION
Added support for the new `QUERY` http method, this require the http crate to be published the current git upstream have the method but not crates.io