### PR TITLE
Fix spurious TooLarge disconnect on keep-alive connections (Inner::consumed never reset)

### DIFF
--- a/ntex/src/http/h1/decoder.rs
+++ b/ntex/src/http/h1/decoder.rs
@@ -164,6 +164,7 @@ impl<T: MessageType> Decoder for MessageDecoder<T> {
                     let len = inner.st.payload_length();
                     let pl = val.set_payload_length(&mut inner.st, len)?;
                     inner.st = State::default();
+                    inner.consumed = 0;
                     self.hdrs.set(false);
                     Ok(Some((val, pl)))
                 }


### PR DESCRIPTION
Fixes #946.

## Problem

`Inner::consumed` (`ntex/src/http/h1/decoder.rs`) is meant to bound the current in-flight
message's header size against `HttpServiceConfig::max_buf_size` (default 64 KiB). It's
initialized once per connection (not per message) and never reset when a message completes
successfully, so it accumulates monotonically for the connection's entire lifetime.

On a long-lived keep-alive connection, the cumulative total eventually crosses `max_buf_size`
just from ordinary successfully-served traffic. Once it does, the next request that happens to
arrive split across two reads (an everyday TCP occurrence, not anything unusual) trips the
`TooLarge` check and gets spuriously rejected/disconnected — even though that request is
trivially small on its own.

Full write-up with exact reproduction in #946.

## Fix

One line: reset `inner.consumed = 0` at the same point the decoder already resets its other
per-message state (`inner.st = State::default()`), when a message finishes parsing
successfully. `consumed`'s only reader is the `TooLarge` check a few lines later in the same
function, so this restores the field's intent (bound the *current* message) without touching
anything else.

## Testing

`cargo check -p ntex` builds clean with this change.

I validated the fix functionally with an external harness against a local build at this pin:
1261 complete valid requests, then one ordinary 30-byte partial request.
- Unpatched: `Phase B: ... REJECTED: TooLarge(65602)`
- Patched (this branch): `Phase B: partial request (30B) correctly treated as 'need more data'`

Per [maintainer guidance](https://github.com/ntex-rs/ntex/pull/947#issuecomment-5060464753), also
ran the full test suite with `--no-default-features`:

```
cargo test -p ntex --no-default-features --features="tokio,cookie,url,compress,openssl,rustls,ws" --lib
```

**278 passed, 0 failed, 0 ignored** — including all 44 in `http::h1::decoder::tests` (e.g.
`test_content_length_and_te_http10`, `test_transfer_encoding_content_length_combination`) and the
3 in `http::h1::dispatcher::tests`. Haven't tried `cargo nextest` specifically (not installed
locally) but `cargo test` with these flags compiles and passes clean.

