### PR TITLE
Enforce max_buf_size for complete message heads and respond with 431

### DIFF
--- a/ntex/CHANGES.md
+++ b/ntex/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## [3.11.1] - 2026-0x-xx
+
+* Enforce `max_buf_size` for complete message heads; previously the limit was only
+  checked while a message head was still partial, so a head that fit in a single
+  read could exceed it
+
+* Respond with "431 Request Header Fields Too Large" instead of "400 Bad Request"
+  when a message head exceeds `max_buf_size`
+
 ## [3.11.0] - 2026-07-24
 
 * Replace httparse with ntex-httparse

--- a/ntex/src/http/h1/decoder.rs
+++ b/ntex/src/http/h1/decoder.rs
@@ -160,6 +160,11 @@ impl<T: MessageType> Decoder for MessageDecoder<T> {
         let result = if inner.val.is_some() {
             match MessageDecoder::<T>::decode_headers(src, &mut inner) {
                 Poll::Ready(Ok(())) => {
+                    let consumed = inner.consumed + (len - src.len());
+                    if consumed >= inner.cfg.max_buf_size {
+                        log::trace!("MAX_BUFFER_SIZE of data reached, closing");
+                        return Err(DecodeError::TooLarge(consumed));
+                    }
                     let mut val = inner.val.take().unwrap();
                     let len = inner.st.payload_length();
                     let pl = val.set_payload_length(&mut inner.st, len)?;
@@ -1666,5 +1671,42 @@ mod tests {
         let mut buf = BytesMut::from(TEXT);
         let err = reader.decode(&mut buf).err().unwrap();
         assert_eq!(err, DecodeError::MaxHeaders);
+    }
+
+    #[test]
+    fn test_max_buf_size_complete_message() {
+        const TEXT: &str = "GET /test HTTP/1.1\r\n\
+             Host: example.com\r\n\
+             Content-Length: 3\r\n\
+             Test-header: ****\r\n\
+             \r\n";
+
+        // whole message head is available in one buffer
+        let cfg: SharedCfg = SharedCfg::new("test")
+            .add(HttpServiceConfig::new().set_max_buf_size(10))
+            .into();
+        let reader = MessageDecoder::<Request>::new(cfg.get());
+        let mut buf = BytesMut::from(TEXT);
+        let err = reader.decode(&mut buf).err().unwrap();
+        assert_eq!(err, DecodeError::TooLarge(79));
+
+        // message head completes on the second read
+        let cfg: SharedCfg = SharedCfg::new("test")
+            .add(HttpServiceConfig::new().set_max_buf_size(78))
+            .into();
+        let reader = MessageDecoder::<Request>::new(cfg.get());
+        let mut buf = BytesMut::from(&TEXT[..77]);
+        assert!(reader.decode(&mut buf).unwrap().is_none());
+        buf.extend_from_slice(&TEXT.as_bytes()[77..]);
+        let err = reader.decode(&mut buf).err().unwrap();
+        assert_eq!(err, DecodeError::TooLarge(79));
+
+        // message head size is within the limit
+        let cfg: SharedCfg = SharedCfg::new("test")
+            .add(HttpServiceConfig::new().set_max_buf_size(100))
+            .into();
+        let reader = MessageDecoder::<Request>::new(cfg.get());
+        let mut buf = BytesMut::from(TEXT);
+        assert!(reader.decode(&mut buf).unwrap().is_some());
     }
 }

--- a/ntex/src/http/h1/dispatcher.rs
+++ b/ntex/src/http/h1/dispatcher.rs
@@ -1105,7 +1105,10 @@ mod tests {
         assert!(h1.inner.io.is_closed());
 
         let mut buf = BytesMut::from(&client.read().await.unwrap()[..]);
-        assert_eq!(load(&mut decoder, &mut buf).status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            load(&mut decoder, &mut buf).status,
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+        );
     }
 
     #[crate::rt_test]

--- a/ntex/src/http/h1/mod.rs
+++ b/ntex/src/http/h1/mod.rs
@@ -71,9 +71,10 @@ pub enum ProtocolError {
 impl super::ResponseError for ProtocolError {
     fn error_response(&self) -> super::Response {
         match self {
-            ProtocolError::Decode(super::error::DecodeError::MaxHeaders) => {
-                super::Response::RequestHeaderFieldsTooLarge().into()
-            }
+            ProtocolError::Decode(
+                super::error::DecodeError::MaxHeaders
+                | super::error::DecodeError::TooLarge(_),
+            ) => super::Response::RequestHeaderFieldsTooLarge().into(),
             ProtocolError::Decode(_) => super::Response::BadRequest().into(),
             ProtocolError::SlowRequestTimeout | ProtocolError::SlowPayloadTimeout => {
                 super::Response::RequestTimeout().into()


### PR DESCRIPTION
## What

Two related fixes to `max_buf_size` handling in the h1 decoder:

1. **Enforce the limit for complete message heads.** Since #948 the `max_buf_size` check only runs while a message head is still partial (`pending` path). A head that parses to completion within a single `decode` call is never measured, so it can exceed the configured limit without being rejected — e.g. with `set_max_buf_size(8 * 1024)`, a 32KB header block arriving in one read burst is accepted. The decoder drains every head byte from the buffer during parsing, so the exact head size is available on completion as `inner.consumed + (len - src.len())`; check it against `max_buf_size` before returning the message. This is precise under pipelining since unparsed follow-up bytes stay in `src`.

2. **Respond with `431 Request Header Fields Too Large` instead of `400 Bad Request`** when the head exceeds `max_buf_size` (`DecodeError::TooLarge`), matching the existing `MaxHeaders` handling and RFC 6585. Note this also changes the response for the existing partial-path rejection from 400 to 431 — observable behavior change, called out in CHANGES.md.

## Tests

- New `test_max_buf_size_complete_message` covering: complete head in one buffer (previously accepted, now rejected), head completing on a second read, and an under-limit head. The first case fails without the decoder fix.
- Updated `test_read_large_message` to expect 431.
- Full suite green with the CI feature set; fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)